### PR TITLE
Add context close codes and make extensibility binary

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -491,7 +491,7 @@ its local policy. The endpoint that had originally registered this context MUST
 NOT try to register another context with the same context extensions on this
 stream.
 
-RESSOURCE_LIMIT (code=0x02):
+RESOURCE_LIMIT (code=0x02):
 
 : This indicates that the context was closed to save resources. The recipient
 SHOULD limit its future registration of resource-incentive contexts.
@@ -708,7 +708,7 @@ This registry initially contains the following entries:
 +------------------------------+-------+---------------+
 | DENIED                       | 0x01  | This Document |
 +------------------------------+-------+---------------+
-| RESSOURCE_LIMIT              | 0x02  | This Document |
+| RESOURCE_LIMIT              | 0x02  | This Document |
 +------------------------------+-------+---------------+
 ~~~
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -402,6 +402,12 @@ endpoint receives a CLOSE_DATAGRAM_CONTEXT capsule that violates one or more of
 these requirements, the endpoint MUST abruptly terminate the corresponding
 stream with a stream error of type H3_GENERAL_PROTOCOL_ERROR.
 
+All CLOSE_DATAGRAM_CONTEXT capsules MUST contain a CLOSE_CODE context
+extension, see {{close-code}}. If an endpoint receives a CLOSE_DATAGRAM_CONTEXT
+capsule without a CLOSE_CODE context extension, the endpoint MUST abruptly
+terminate the corresponding stream with a stream error of type
+H3_GENERAL_PROTOCOL_ERROR.
+
 
 ## The DATAGRAM Capsule {#datagram-capsule}
 
@@ -496,10 +502,8 @@ RESOURCE_LIMIT (code=0x02):
 : This indicates that the context was closed to save resources. The recipient
 SHOULD limit its future registration of resource-incentive contexts.
 
-If CLOSE_CODE is not present in a CLOSE_DATAGRAM_CONTEXT capsule, the recipient
-SHALL treat it as if the NO_ERROR code was present. Close codes are registered
-with IANA, see {{iana-close-codes}}. Receipt of an unknown close code MUST be
-treated as if the NO_ERROR code was present.
+Receipt of an unknown close code MUST be treated as if the NO_ERROR code was
+present. Close codes are registered with IANA, see {{iana-close-codes}}.
 
 
 ## The DETAILS Context Extension Type

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -839,7 +839,7 @@ DATAGRAM                       -------->
 STREAM(44): CAPSULE             -------->
   Capsule Type = REGISTER_DATAGRAM_CONTEXT
   Context ID = 2
-  Context Extension = {IP_COMPRESSION=192.0.2.42:443}
+  Context Extension = {IP_COMPRESSION=tcp,192.0.2.6:9876,192.0.2.7:443}
 
 DATAGRAM                       -------->
   Quarter Stream ID = 11


### PR DESCRIPTION
This PR adds a new concept of context close codes which
will allow applications that use contexts to indicate
the reason for closing a context.

This PR also makes the extensibility mechanism binary as
that is easier to implement.

Closes #53.