### PR TITLE
Treat malformed capsules as stream errors

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -217,21 +217,20 @@ Intermediaries parse the Quarter Stream ID field in order to associate the QUIC
 DATAGRAM frame with a stream. If an intermediary receives a QUIC DATAGRAM frame
 whose payload is too short to allow parsing the Quarter Stream ID field, the
 intermediary MUST treat it as an HTTP/3 connection error of type
-H3_GENERAL_PROTOCOL_ERROR. The Context ID field is optional and whether it is
-present or not is decided end-to-end by the endpoints, see {{context-hdr}}.
-Therefore intermediaries cannot know whether the Context ID field is present or
-absent and they MUST ignore any HTTP/3 Datagram fields after the Quarter Stream
-ID.
+H3_DATAGRAM_ERROR. The Context ID field is optional and whether it is present or
+not is decided end-to-end by the endpoints, see {{context-hdr}}.  Therefore
+intermediaries cannot know whether the Context ID field is present or absent and
+they MUST ignore any HTTP/3 Datagram fields after the Quarter Stream ID.
 
 Endpoints parse both the Quarter Stream ID field and the Context ID field in
-order to associate the QUIC DATAGRAM frame with a stream and context within
-that stream. If an endpoint receives a QUIC DATAGRAM frame whose payload is too
-short to allow parsing the Quarter Stream ID field, the endpoint MUST treat it
-as an HTTP/3 connection error of type H3_GENERAL_PROTOCOL_ERROR. If an endpoint
-receives a QUIC DATAGRAM frame whose payload is long enough to allow parsing
-the Quarter Stream ID field but too short to allow parsing the Context ID
-field, the endpoint MUST abruptly terminate the corresponding stream with a
-stream error of type H3_GENERAL_PROTOCOL_ERROR.
+order to associate the QUIC DATAGRAM frame with a stream and context within that
+stream. If an endpoint receives a QUIC DATAGRAM frame whose payload is too short
+to allow parsing the Quarter Stream ID field, the endpoint MUST treat it as an
+HTTP/3 connection error of type H3_DATAGRAM_ERROR. If an endpoint receives a
+QUIC DATAGRAM frame whose payload is long enough to allow parsing the Quarter
+Stream ID field but too short to allow parsing the Context ID field, the
+endpoint MUST abruptly terminate the corresponding stream with a stream error of
+type H3_DATAGRAM_ERROR.
 
 Endpoints MUST NOT send HTTP/3 datagrams unless the corresponding stream's send
 side is open. On a given endpoint, once the receive side of a stream is closed,
@@ -364,7 +363,8 @@ the message as malformed or incomplete, according to the underlying transport
 protocol.  For HTTP/3, the handling of malformed messages is described in
 section 4.1.3 of {{H3}}.  For HTTP/2, the handling of malformed messages is
 described in section 8.1.2.6 of {{!H2=RFC7540}}.  For HTTP/1.1, the handling of
-incomplete messages is described in section 8 of {{!CORE-MESSAGING=I-D.draft-ietf-httpbis-messaging}}.
+incomplete messages is described in section 8 of
+{{!CORE-MESSAGING=I-D.draft-ietf-httpbis-messaging}}.
 
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -361,7 +361,7 @@ drop that Capsule.
 
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the
-identified fields or a frame payload that terminates before the end of the
+identified fields or a capsule payload that terminates before the end of the
 identified fields MUST be treated as a stream error of type H3_FRAME_ERROR. In
 particular, redundant length encodings MUST be verified to be self-consistent.
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -196,7 +196,7 @@ client-initiated bidirectional streams, and those have stream IDs that are
 divisible by four). The largest legal QUIC stream ID value is 2<sup>62</sup>-1,
 so the largest legal value of Quarter Stream ID is 2<sup>62</sup>-1 / 4.
 Receipt of a frame that includes a larger value MUST be treated as a connection
-error of type FRAME_ENCODING_ERROR.
+error of type H3_FRAME_ERROR.
 
 Context ID:
 
@@ -357,6 +357,17 @@ the same order.
 Endpoints which receive a Capsule with an unknown Capsule Type MUST silently
 drop that Capsule.
 
+## Error Handling
+
+Each capsule's payload MUST contain exactly the fields identified in its
+description. A capsule payload that contains additional bytes after the
+identified fields or a frame payload that terminates before the end of the
+identified fields MUST be treated as a stream error of type H3_FRAME_ERROR. In
+particular, redundant length encodings MUST be verified to be self-consistent.
+
+When a stream carrying capsules terminates cleanly, if the last capsule on the
+stream was truncated, this MUST be treated as a stream error of type
+H3_FRAME_ERROR.
 
 ## Capsule Types
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -196,7 +196,7 @@ client-initiated bidirectional streams, and those have stream IDs that are
 divisible by four). The largest legal QUIC stream ID value is 2<sup>62</sup>-1,
 so the largest legal value of Quarter Stream ID is 2<sup>62</sup>-1 / 4.
 Receipt of a frame that includes a larger value MUST be treated as a connection
-error of type H3_FRAME_ERROR.
+error of type TBD.
 
 Context ID:
 
@@ -359,15 +359,20 @@ drop that Capsule.
 
 ## Error Handling
 
+When an error occurs processing the capsule protocol, the receiver abruptly
+terminates the enclosing stream.  When running over HTTP/3 or HTTP/2, the
+receiver resets the stream.  When running over HTTP/1.1, the receiver terminates
+the underlying connection with an error.
+
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the
 identified fields or a capsule payload that terminates before the end of the
-identified fields MUST be treated as a stream error of type H3_FRAME_ERROR. In
+identified fields MUST be treated as a stream error of type TBD. In
 particular, redundant length encodings MUST be verified to be self-consistent.
 
 When a stream carrying capsules terminates cleanly, if the last capsule on the
 stream was truncated, this MUST be treated as a stream error of type
-H3_FRAME_ERROR.
+TBD.
 
 ## Capsule Types
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -196,7 +196,7 @@ client-initiated bidirectional streams, and those have stream IDs that are
 divisible by four). The largest legal QUIC stream ID value is 2<sup>62</sup>-1,
 so the largest legal value of Quarter Stream ID is 2<sup>62</sup>-1 / 4.
 Receipt of a frame that includes a larger value MUST be treated as a connection
-error of type TBD.
+error of type H3_DATAGRAM_ERROR.
 
 Context ID:
 
@@ -359,20 +359,21 @@ drop that Capsule.
 
 ## Error Handling
 
-When an error occurs processing the capsule protocol, the receiver abruptly
-terminates the enclosing stream.  When running over HTTP/3 or HTTP/2, the
-receiver resets the stream.  When running over HTTP/1.1, the receiver terminates
-the underlying connection with an error.
+When an error occurs processing the capsule protocol, the receiver MUST treat
+the message as malformed or incomplete, according to the underlying transport
+protocol.  For HTTP/3, the handling of malformed messages is described in
+section 4.1.3 of {{H3}}.  For HTTP/2, the handling of malformed messages is
+described in section 8.1.2.6 of {{!H2=RFC7540}}.  For HTTP/1.1, the handling of
+incomplete messages is described in section 8 of {{!CORE-MESSAGING=I-D.draft-ietf-httpbis-messaging}}.
 
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the
 identified fields or a capsule payload that terminates before the end of the
-identified fields MUST be treated as a stream error of type TBD. In
+identified fields MUST be treated as a malformed or incomplete message. In
 particular, redundant length encodings MUST be verified to be self-consistent.
 
 When a stream carrying capsules terminates cleanly, if the last capsule on the
-stream was truncated, this MUST be treated as a stream error of type
-TBD.
+stream was truncated, this MUST be treated as a malformed or incomplete message.
 
 ## Capsule Types
 
@@ -734,6 +735,18 @@ This document will request IANA to register the following entry in the
 |:-------------|:---------|:--------------|:--------|
 | H3_DATAGRAM  | 0xffd277 | This Document |    0    |
 {: #iana-setting-table title="New HTTP/3 Settings"}
+
+
+## HTTP/3 Error Code {#iana-error}
+
+This document will request IANA to register the following entry in the
+"HTTP/3 Error Code" registry:
+
+| Name              |   Value  | Description    | Specification |
+|:------------------|:---------|:---------------|:--------------|
+| H3_DATAGRAM_ERROR |  0x0111  | Datagram parse | This document |
+|                   |          | error          |               |
+{: #iana-error-table title="New HTTP/3 Error Codes"}
 
 
 ## HTTP Header Field Name {#iana-hdr}


### PR DESCRIPTION
Borrowing text from H3.  Also I don't think there is a 'FRAME_ENCODING_ERROR' defined anywhere.