### PR TITLE
Simplify by removing formats and registration

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -70,8 +70,8 @@ This document is structured as follows:
 * {{capsule}} introduces the Capsule Protocol and the "data stream" concept.
   Data streams are initiated using special-purpose HTTP requests, after which
   Capsules, an end-to-end message, can be sent.
-  * Datagram Capsule types {{datagram-capsule}} are defined, along with guidance
-    for defining new capsule types.
+  * {{datagram-capsule}} defines Datagram Capsule types, along with guidance
+    for specifying new capsule types.
 
 
 ## Conventions and Definitions {#defs}

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -61,11 +61,7 @@ This document is structured as follows:
 
 * {{multiplexing}} presents core concepts for multiplexing across HTTP versions.
   * {{datagram-contexts}} defines datagram contexts, an optional end-to-end
-    multiplexing concept scoped to each HTTP request. Whether contexts are in
-    use is defined in {{context-hdr}}.
-  * {{datagram-formats}} defines datagram formats, which are scoped to contexts.
-    Formats communicate the format and encoding of datagrams sent using the
-    associated context.
+    multiplexing concept scoped to each HTTP request.
   * Contexts are identified using a variable-length integer. Requirements for
     allocating identifier values are detailed in {{context-id-alloc}}.
 * {{format}} defines how QUIC DATAGRAM frames are used with HTTP/3. {{setting}}
@@ -74,10 +70,8 @@ This document is structured as follows:
 * {{capsule}} introduces the Capsule Protocol and the "data stream" concept.
   Data streams are initiated using special-purpose HTTP requests, after which
   Capsules, an end-to-end message, can be sent.
-  * The following Capsule types are defined, together with guidance for defining new types:
-    * Datagram registration capsules {{register-capsule}}
-    * Datagram close capsule {{close-capsule}}
-    * Datagram capsules {{datagram-capsule}}
+  * Datagram Capsule types {{datagram-capsule}} are defined, along with guidance
+    for defining new capsule types.
 
 
 ## Conventions and Definitions {#defs}
@@ -114,42 +108,29 @@ compression to elide some parts of the datagram: the context identifier then
 maps to a compression context that the receiver can use to reconstruct the
 elided data.
 
+Any HTTP Methods or protocols enabled by HTTP Upgrade Tokens that use HTTP
+Datagrams MUST define the format of datagrams for the default context, which
+has a context ID of 0.
+
+Non-default contexts (contexts with a non-zero ID) are OPTIONAL to implement
+for both endpoints. Intermediaries do not require any context-specific software
+to enable such contexts. Methods or protocols that use HTTP Datagrams can
+independently define whether or not non-default contexts are supported, and
+how to negotiate support for contexts if needed. Such methods or protocols
+can define new HTTP Capsule types ({{capsule-protocol}}) to register
+a context ID and indicate the meaning or format of datagrams that have that
+context ID. For guidance on registering contexts with capsules, see
+{{register-capsules}}.
+
 While stream IDs are a per-hop concept, context IDs are an end-to-end concept.
 In other words, if a datagram travels through one or more intermediaries on its
 way from client to server, the stream ID will most likely change from hop to
 hop, but the context ID will remain the same. Context IDs are opaque to
 intermediaries.
 
-Contexts are OPTIONAL to implement for both endpoints. Intermediaries do not
-require any context-specific software to enable contexts. When contexts are
-supported by the implementation, their use is optional and can be selected on
-each stream. Endpoints inform their peer of whether they wish to use contexts
-via the Sec-Use-Datagram-Contexts HTTP header, see {{context-hdr}}.
-
 When contexts are used, they are identified within the scope of a given request
 by a numeric value, referred to as the context ID. A context ID is a 62-bit
 integer (0 to 2<sup>62</sup>-1).
-
-
-## Datagram Formats {#datagram-formats}
-
-When an endpoint registers a datagram context (or the lack of contexts), it
-communicates the format (i.e., the semantics and encoding) of datagrams sent
-using this context. This is acccomplished by sending a Datagram Format Type as
-part of the datagram registration capsule, see {{register-capsule}}. This type
-identifier is registered with IANA (see {{iana-format-types}}) and allows
-applications that use HTTP Datagrams to indicate what the content of datagrams
-are. Registration capsules carry a Datagram Format Additional Data field which
-allows sending some additional information that would impact the format of
-datagrams.
-
-For example, a protocol which proxies IP packets can define a Datagram Format
-Type which represents an IP packet. The corresponding Datagram Format
-Additional Data field would be empty. An extension to such a protocol that
-wishes to compress IP addresses could define a distinct Datagram Format Type
-and exchange two IP addresses via the Datagram Format Additional Data field.
-Then any datagrams with that type would contain the IP packet with addresses
-elided.
 
 
 ## Context ID Allocation {#context-id-alloc}
@@ -180,56 +161,57 @@ of {{QUIC}}):
 
 ~~~
 HTTP/3 Datagram {
-  Quarter Stream ID (i),
+  Encoded Stream ID (i),
   [Context ID (i)],
   HTTP Datagram Payload (..),
 }
 ~~~
 {: #h3-datagram-format title="HTTP/3 DATAGRAM Format"}
 
-Quarter Stream ID:
+Encoded Stream ID:
 
-: A variable-length integer that contains the value of the client-initiated
-bidirectional stream that this datagram is associated with, divided by four (the
-division by four stems from the fact that HTTP requests are sent on
-client-initiated bidirectional streams, and those have stream IDs that are
-divisible by four). The largest legal QUIC stream ID value is 2<sup>62</sup>-1,
-so the largest legal value of Quarter Stream ID is 2<sup>62</sup>-1 / 4.
-Receipt of a frame that includes a larger value MUST be treated as a connection
-error of type FRAME_ENCODING_ERROR.
+: A variable-length integer that contains an encoded value indicating the
+client-initiated bidirectional stream that this datagram is associated with.
+The Encoded Stream ID for a datagram without a context ID is the associated
+stream ID divided by two. The Encoded Stream ID for a datagram with a context
+ID is the associated stream ID divided by two, plus one. (Client-initiated
+bidirectional streams have stream IDs that are divisible by four, so the
+stream ID divided by two always has the least-significant bit set to zero).
+The largest legal QUIC stream ID value is 2<sup>62</sup>-1, so the largest legal
+value of Encoded Stream ID is (2<sup>62</sup>-1 / 2) + 1. Receipt of a frame that
+includes a larger value MUST be treated as a connection error of type
+FRAME_ENCODING_ERROR. A datagram without a context ID is implicitly using
+a context ID of 0.
 
 Context ID:
 
 : A variable-length integer indicating the context ID of the datagram (see
 {{datagram-contexts}}). Whether or not this field is present depends on whether
-datagram contexts are in use on this stream, see {{context-hdr}}. If this QUIC
-DATAGRAM frame is reordered and arrives before the receiver knows whether
-datagram contexts are in use on this stream, then the receiver cannot parse
-this datagram and the receiver MUST either drop that datagram silently or
-buffer it temporarily.
+the least-significant bit of the Encoded Stream ID, as described above. If the
+receiver of a datagram does not support Context IDs, it will drop any datagram
+that contains a context ID.
 
 HTTP Datagram Payload:
 
 : The payload of the datagram, whose semantics are defined by individual
 applications. Note that this field can be empty.
 
-Intermediaries parse the Quarter Stream ID field in order to associate the QUIC
-DATAGRAM frame with a stream. If an intermediary receives a QUIC DATAGRAM frame
-whose payload is too short to allow parsing the Quarter Stream ID field, the
-intermediary MUST treat it as an HTTP/3 connection error of type
-H3_GENERAL_PROTOCOL_ERROR. The Context ID field is optional and whether it is
-present or not is decided end-to-end by the endpoints, see {{context-hdr}}.
-Therefore intermediaries cannot know whether the Context ID field is present or
-absent and they MUST ignore any HTTP/3 Datagram fields after the Quarter Stream
-ID.
+Intermediaries parse the Encoded Stream ID field in order to associate the QUIC
+DATAGRAM frame with a stream. This is done by first checking if the
+least-significant bit of the Encoded Stream ID is set (which indicates if the
+datagram includes a context ID), clearing that bit, and multiplying the result
+by two to generate the client-initiated bidirectional stream ID. If an
+intermediary receives a QUIC DATAGRAM frame whose payload is too short to
+allow parsing the Encoded Stream ID field, the intermediary MUST treat it as
+an HTTP/3 connection error of type H3_GENERAL_PROTOCOL_ERROR.
 
-Endpoints parse both the Quarter Stream ID field and the Context ID field in
+Endpoints parse both the Encoded Stream ID field and the Context ID field in
 order to associate the QUIC DATAGRAM frame with a stream and context within
 that stream. If an endpoint receives a QUIC DATAGRAM frame whose payload is too
-short to allow parsing the Quarter Stream ID field, the endpoint MUST treat it
+short to allow parsing the Encoded Stream ID field, the endpoint MUST treat it
 as an HTTP/3 connection error of type H3_GENERAL_PROTOCOL_ERROR. If an endpoint
 receives a QUIC DATAGRAM frame whose payload is long enough to allow parsing
-the Quarter Stream ID field but too short to allow parsing the Context ID
+the Encoded Stream ID field but too short to allow parsing the Context ID
 field, the endpoint MUST abruptly terminate the corresponding stream with a
 stream error of type H3_GENERAL_PROTOCOL_ERROR.
 
@@ -240,7 +222,7 @@ release related state. Endpoints MAY keep state for a short time to account for
 reordering. Once the state is released, the endpoint MUST silently drop
 received associated datagrams.
 
-If an HTTP/3 datagram is received and its Quarter Stream ID maps to a stream
+If an HTTP/3 datagram is received and its Encoded Stream ID maps to a stream
 that has not yet been created, the receiver SHALL either drop that datagram
 silently or buffer it temporarily while awaiting the creation of the
 corresponding stream.
@@ -358,169 +340,7 @@ Endpoints which receive a Capsule with an unknown Capsule Type MUST silently
 drop that Capsule.
 
 
-## Capsule Types
-
-### The Datagram Registration Capsules {#register-capsule}
-
-This document defines the REGISTER_DATAGRAM and REGISTER_DATAGRAM_CONTEXT
-capsules types, known collectively as the datagram registration capsules (see
-{{iana-types}} for the value of the capsule types). The REGISTER_DATAGRAM
-capsule is used by endpoints to inform their peer of the encoding and semantics
-of all datagrams associated with a stream. The REGISTER_DATAGRAM_CONTEXT
-capsule is used by endpoints to inform their peer of the encoding and semantics
-of all datagrams associated with a given context ID on this stream.
-
-~~~
-Datagram Registration Capsule {
-  Type (i) = REGISTER_DATAGRAM or REGISTER_DATAGRAM_CONTEXT,
-  Length (i),
-  [Context ID (i)],
-  Datagram Format Type (i),
-  Datagram Format Additional Data (..),
-}
-~~~
-{: #register-capsule-format title="REGISTER_DATAGRAM_CONTEXT Capsule Format"}
-
-Context ID:
-
-: A variable-length integer indicating the context ID to register (see
-{{datagram-contexts}}). This field is present in REGISTER_DATAGRAM_CONTEXT
-capsules but not in REGISTER_DATAGRAM capsules. If a REGISTER_DATAGRAM capsule
-is used on a stream where datagram contexts are in use, it is associated with
-context ID 0. REGISTER_DATAGRAM_CONTEXT capsules MUST NOT carry context ID 0 as
-that context ID is conveyed using the REGISTER_DATAGRAM capsule.
-
-Datagram Format Type:
-
-: A variable-length integer that defines the semantics and encoding of the HTTP
-Datagram Payload field of datagrams with this context ID, see
-{{datagram-formats}}.
-
-Datagram Format Additional Data:
-
-: This field carries additional information that impact the format of datagrams
-with this context ID, see {{datagram-formats}}.
-
-Note that these registrations are unilateral and bidirectional: the sender of
-the capsule unilaterally defines the semantics it will apply to the datagrams
-it sends and receives using this context ID. Once a context ID is registered,
-it can be used in both directions.
-
-Endpoints MUST NOT send HTTP Datagrams until they have either sent or received
-a datagram registration capsule with the same Context ID. However, reordering
-can cause HTTP Datagrams to be received with an unknown Context ID. Receipt of
-such HTTP datagrams MUST NOT be treated as an error. Endpoints SHALL drop the
-HTTP Datagram silently, or buffer it temporarily while awaiting the
-corresponding datagram registration capsule. Intermediaries SHALL drop the HTTP
-Datagram silently, MAY buffer it, or forward it on immediately.
-
-Endpoints MUST NOT register the same Context ID twice on the same stream. This
-also applies to Context IDs that have been closed using a
-CLOSE_DATAGRAM_CONTEXT capsule. Clients MUST NOT register server-initiated
-Context IDs and servers MUST NOT register client-initiated Context IDs. If an
-endpoint receives a REGISTER_DATAGRAM_CONTEXT capsule that violates one or more
-of these requirements, the endpoint MUST abruptly terminate the corresponding
-stream with a stream error of type H3_GENERAL_PROTOCOL_ERROR.
-
-If datagrams contexts are not in use, the client is responsible for choosing
-the datagram format and informing the server via a REGISTER_DATAGRAM capsule.
-Servers MUST NOT send the REGISTER_DATAGRAM capsule. If a client receives a
-REGISTER_DATAGRAM capsule, the client MUST abruptly terminate the corresponding
-stream with a stream error of type H3_GENERAL_PROTOCOL_ERROR.
-
-
-### The Datagram Close Capsule {#close-capsule}
-
-The CLOSE_DATAGRAM_CONTEXT capsule (see {{iana-types}} for the value of the
-capsule type) allows an endpoint to inform its peer that it will no longer send
-or parse received datagrams associated with a given context ID.
-
-~~~
-CLOSE_DATAGRAM_CONTEXT Capsule {
-  Type (i) = CLOSE_DATAGRAM_CONTEXT,
-  Length (i),
-  Context ID (i),
-  Close Code (i),
-  Close Details (..),
-}
-~~~
-{: #close-capsule-format title="CLOSE_DATAGRAM_CONTEXT Capsule Format"}
-
-Context ID:
-
-: The context ID to close.
-
-Close Code:
-
-: The close code allows an endpoint to provide additional information as to why
-a datagram context was closed. {{close-codes}} defines a set of codes, the
-circumstances under which an implementation sends them, and how receivers react.
-
-Close Details:
-
-: This is meant for debugging purposes. It consists of a human-readable string
-encoded in UTF-8.
-
-Note that this close is unilateral and bidirectional: the sender of the frame
-unilaterally informs its peer of the closure. Endpoints can use
-CLOSE_DATAGRAM_CONTEXT capsules to close a context that was initially
-registered by either themselves, or by their peer. Endpoints MAY use the
-CLOSE_DATAGRAM_CONTEXT capsule to immediately reject a context that was just
-registered using a REGISTER_DATAGRAM_CONTEXT capsule if they find its Datagram
-Format Type field to be unacceptable.
-
-After an endpoint has either sent or received a CLOSE_DATAGRAM_CONTEXT frame,
-it MUST NOT send any HTTP Datagrams with that Context ID. However, due to
-reordering, an endpoint that receives an HTTP Datagram with a closed Context ID
-MUST NOT treat it as an error, it SHALL instead drop the HTTP Datagram
-silently.
-
-Endpoints MUST NOT close a Context ID that was not previously registered.
-Endpoints MUST NOT close a Context ID that has already been closed. If an
-endpoint receives a CLOSE_DATAGRAM_CONTEXT capsule that violates one or more of
-these requirements, the endpoint MUST abruptly terminate the corresponding
-stream with a stream error of type H3_GENERAL_PROTOCOL_ERROR.
-
-
-#### Close Codes {#close-codes}
-
-Close codes are intended to allow implementations to react differently when they
-receive them - for example, some close codes require the receiver to not open
-another context under certain conditions.
-
-This specification defines the close codes below. Their numeric values are in
-{{iana-close-codes}}. Extensions to this mechanism MAY define new close codes
-and they SHOULD state how receivers react to them.
-
-NO_ERROR:
-
-: This indicates that a context was closed without any action specified for the
-receiver.
-
-UNKNOWN_FORMAT:
-
-: This indicates that the sender does not know how to interpret the datagram
-format type associated with this context. The endpoint that had originally
-registered this context MUST NOT try to register another context with the same
-datagram format type on this stream.
-
-DENIED:
-
-: This indicates that the sender has rejected the context registration based on
-its local policy. The endpoint that had originally registered this context MUST
-NOT try to register another context with the same datagram format type and
-datagram format data on this stream.
-
-RESOURCE_LIMIT:
-
-: This indicates that the context was closed to save resources. The recipient
-SHOULD limit its future registration of resource-intensive contexts.
-
-Receipt of an unknown close code MUST be treated as if the NO_ERROR code was
-present. Close codes are registered with IANA, see {{iana-close-codes}}.
-
-
-### The Datagram Capsules {#datagram-capsule}
+## The Datagram Capsules {#datagram-capsule}
 
 This document defines the DATAGRAM and DATAGRAM_WITH_CONTEXT capsules types,
 known collectively as the datagram capsules (see {{iana-types}} for the value
@@ -583,6 +403,32 @@ loss; this can misrepresent the true path properties, defeating methods such a
 DPLPMTUD.
 
 
+## Registering Datagram Contexts with Capsules {#register-capsules}
+
+Methods or protocols that support multiple datagram payload formats or
+separate types of datagrams can differentiate them using datagram contexts
+({{datagram-contexts}}).
+
+Such protocols can define a new Capsule type that is used to register
+a context ID with the peer endpoint.
+
+For example, if a new method needed to define a non-default context for
+the "Example" datagram format, it could define a new capsule type
+(REGISTER_EXAMPLE_FORMAT) that indcludes a context ID value. Endpoints
+that understand this new capsule type would be able to consequently
+handle and parse datagrams on the context ID, while all other endpoints
+would ignore the datagrams.
+
+~~~
+REGISTER_EXAMPLE_FORMAT Capsule {
+  Type (i) = REGISTER_EXAMPLE_FORMAT, // For example only
+  Length (i),
+  Context ID (i),
+}
+~~~
+{: #example-capsule-format title="REGISTER_EXAMPLE_FORMAT Capsule Format"}
+
+
 # The H3_DATAGRAM HTTP/3 SETTINGS Parameter {#setting}
 
 Implementations of HTTP/3 that support HTTP Datagrams can indicate that to
@@ -621,70 +467,6 @@ endpoint has sent and received SETTINGS, it MUST compute the intersection of
 the values it has sent and received, and then it MUST select and use the most
 recent draft version from the intersection set. This ensures that both
 endpoints negotiate the same draft version.
-
-
-# The Sec-Use-Datagram-Contexts HTTP Header {#context-hdr}
-
-Endpoints indicate their support for datagram contexts by sending the
-Sec-Use-Datagram-Contexts header with a value of ?1. If the header is missing
-or has a value different from ?1, that indicates that its sender does not wish
-to use datagram contexts. Endpoints that wish to use datagram contexts SHALL
-send the Sec-Use-Datagram-Contexts header with a value of ?1 on requests and
-responses that use the capsule protocol.
-
-"Sec-Use-Datagram-Contexts" is an Item Structured Header {{!RFC8941}}. Its
-value MUST be a Boolean, its ABNF is:
-
-~~~
-Sec-Use-Datagram-Contexts = sf-boolean
-~~~
-
-The REGISTER_DATAGRAM_CONTEXT, DATAGRAM_WITH_CONTEXT, and
-CLOSE_DATAGRAM_CONTEXT capsules as refered to as context-related capsules.
-Endpoints which do not wish to use contexts MUST NOT send context-related
-capsules, and MUST silently ignore any received context-related capsules.
-
-Both endpoints unilaterally decide whether they wish to use datagram contexts
-on a given stream. Contexts are used on a given stream if and only if both
-endpoints indicate they wish to use them on this stream. Once an endpoint has
-received the HTTP request or response, it knows whether datagram contexts are
-in use on this stream or not.
-
-Conceptually, when datagram contexts are not in use on a stream, all datagrams
-use context ID 0, which is client-initiated. This means that the client chooses
-the datagram format for all datagrams when datagram contexts are not in use.
-
-If datagram contexts are not in use on a stream, endpoints MUST NOT send
-context-related capsules to the peer on that stream. Clients MAY optimistically
-send context-related capsules before learning whether the server wishes to
-support datagram contexts or not.
-
-This allows a client to optimistically use extensions that rely on datagram
-contexts without knowing a priori whether the server supports them, and without
-incurring a latency cost to negotiate extension support. In this scenario, the
-client would send its request with the Sec-Use-Datagram-Contexts header set to
-?1, and register two datagram contexts: the main context would use context ID 0
-and the extension context would use context ID 2. The client then sends a
-REGISTER_DATAGRAM capsule to register the main context, and a
-REGISTER_DATAGRAM_CONTEXT to register the extension context. The client can
-then immediately send DATAGRAM capsules to send main datagrams and
-DATAGRAM_WITH_CONTEXT capsules to send extension datagrams.
-
-* If the server wishes to use datagram contexts, it will set
-  Sec-Use-Datagram-Contexts to ?1 on its response and correctly parse all the
-  received capsules.
-
-* If the server does not wish to use datagram contexts (for example if the
-  server implementation does not support them), it will not set
-  Sec-Use-Datagram-Contexts to ?1 on its response. It will then parse the
-  REGISTER_DATAGRAM and DATAGRAM capsules without datagram contexts being in
-  use on this stream, and parse the main datagrams correctly while silently
-  dropping the extension datagrams. Once the client receives the server's
-  response, it will know datagram contexts are not in use, and then will be
-  able to send HTTP Datagrams via the QUIC DATAGRAM frame.
-
-Extensions MAY define a different mechanism to communicate whether contexts are
-in use, and they MAY do so in a way which is opaque to intermediaries.
 
 
 # Prioritization
@@ -773,11 +555,8 @@ This registry initially contains the following entries:
 
 | Capsule Type                 |   Value   | Specification |
 |:-----------------------------|:----------|:--------------|
-| REGISTER_DATAGRAM_CONTEXT    | 0xff37a1  | This Document |
-| REGISTER_DATAGRAM            | 0xff37a2  | This Document |
-| CLOSE_DATAGRAM_CONTEXT       | 0xff37a3  | This Document |
-| DATAGRAM_WITH_CONTEXT        | 0xff37a4  | This Document |
-| DATAGRAM                     | 0xff37a5  | This Document |
+| DATAGRAM                     | 0xff37a1  | This Document |
+| DATAGRAM_WITH_CONTEXT        | 0xff37a2  | This Document |
 {: #iana-types-table title="Initial Capsule Types Registry Entries"}
 
 Capsule types with a value of the form 41 * N + 23 for integer values of N are
@@ -786,77 +565,6 @@ These capsules have no semantics and can carry arbitrary values. These values
 MUST NOT be assigned by IANA and MUST NOT appear in the listing of assigned
 values.
 
-
-## Datagram Format Types {#iana-format-types}
-
-This document establishes a registry for HTTP datagram format type codes. The
-"HTTP Datagram Format Types" registry governs a 62-bit space. Registrations in
-this registry MUST include the following fields:
-
-Type:
-
-: A name or label for the datagram format type.
-
-Value:
-
-: The value of the Datagram Format Type field (see {{datagram-formats}}) is a
-62-bit integer.
-
-Reference:
-
-: An optional reference to a specification for the parameter. This field MAY be
-empty.
-
-Registrations follow the "First Come First Served" policy (see Section 4.4 of
-{{!IANA-POLICY=RFC8126}}) where two registrations MUST NOT have the same Type
-nor Value.
-
-This registry is initially empty.
-
-Datagram format types with a value of the form 41 * N + 17 for integer values
-of N are reserved to exercise the requirement that unknown datagram format
-types be ignored. These format types have no semantics and can carry arbitrary
-values. These values MUST NOT be assigned by IANA and MUST NOT appear in the
-listing of assigned values.
-
-
-## Context Close Codes {#iana-close-codes}
-
-This document establishes a registry for HTTP context close codes. The "HTTP
-Context Close Codes" registry governs a 62-bit space. Registrations in this
-registry MUST include the following fields:
-
-Type:
-
-: A name or label for the close code.
-
-Value:
-
-: The value of the Close Code field (see {{close-capsule}}) is a 62-bit integer.
-
-Reference:
-
-: An optional reference to a specification for the parameter. This field MAY be
-empty.
-
-Registrations follow the "First Come First Served" policy (see Section 4.4 of
-{{!IANA-POLICY=RFC8126}}) where two registrations MUST NOT have the same Type
-nor Value.
-
-This registry initially contains the following entries:
-
-| Context Close Code           |   Value   | Specification |
-|:-----------------------------|:----------|:--------------|
-| NO_ERROR                     | 0xff78a0  | This Document |
-| UNKNOWN_FORMAT               | 0xff78a1  | This Document |
-| DENIED                       | 0xff78a2  | This Document |
-| RESOURCE_LIMIT               | 0xff78a3  | This Document |
-{: #iana-close-codes-table title="Initial Context Close Code Registry Entries"}
-
-Context close codes with a value of the form 41 * N + 19 for integer values of
-N are reserved to exercise the requirement that unknown context close codes be
-treated as NO_ERROR. These values MUST NOT be assigned by IANA and MUST NOT
-appear in the listing of assigned values.
 
 
 --- back
@@ -867,6 +575,7 @@ appear in the listing of assigned values.
 
 In this example, the client does not support any CONNECT-UDP nor HTTP Datagram
 extensions, and therefore has no use for datagram contexts on this stream.
+Each datagram payload is expected to contain a UDP payload.
 
 ~~~
 Client                                             Server
@@ -878,13 +587,8 @@ STREAM(44): HEADERS             -------->
   :path = /target.example.org/443/
   :authority = proxy.example.org:443
 
-STREAM(44): DATA                -------->
-  Capsule Type = REGISTER_DATAGRAM
-  Datagram Format Type = UDP_PAYLOAD
-  Datagram Format Additional Data = ""
-
 DATAGRAM                        -------->
-  Quarter Stream ID = 11
+  Encoded Stream ID = 22
   Payload = Encapsulated UDP Payload
 
            <--------  STREAM(44): HEADERS
@@ -893,7 +597,7 @@ DATAGRAM                        -------->
 /* Wait for target server to respond to UDP packet. */
 
            <--------  DATAGRAM
-                        Quarter Stream ID = 11
+                        Encoded Stream ID = 22
                         Payload = Encapsulated UDP Payload
 ~~~
 
@@ -902,13 +606,17 @@ DATAGRAM                        -------->
 
 In these examples, the client supports a CONNECT-UDP Timestamp Extension, which
 uses a different Datagram Format Type that carries a timestamp followed by the
-encapsulated UDP payload.
+encapsulated UDP payload. Datagrams on the default context (0) are expected to
+contain UDP payloads, while contexts established with the
+REGISTER_UDP_WITH_TIMESTAMP_CONTEXT capsule include a timestamp along with the
+UDP payload. A new header, Sec-UDP-Timestamps, indicates support for the
+extension.
 
 
 ### With Delay
 
 In this instance, the client prefers to wait a round trip to learn whether the
-server supports datagram contexts.
+server supports non-default datagram contexts for the timestamp extension.
 
 ~~~
 Client                                             Server
@@ -919,47 +627,33 @@ STREAM(44): HEADERS            -------->
   :scheme = https
   :path = /target.example.org/443/
   :authority = proxy.example.org:443
-  Sec-Use-Datagram-Contexts = ?1
+  Sec-UDP-Timestamps = ?1
 
            <--------  STREAM(44): HEADERS
                         :status = 200
-                        Sec-Use-Datagram-Contexts = ?1
+                        Sec-UDP-Timestamps = ?1
 
 STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_DATAGRAM_CONTEXT
-  Context ID = 0
-  Datagram Format Type = UDP_PAYLOAD
-  Datagram Format Additional Data = ""
+  Capsule Type = REGISTER_UDP_WITH_TIMESTAMP_CONTEXT
+  Context ID = 2
 
 DATAGRAM                        -------->
-  Quarter Stream ID = 11
-  Context ID = 0
-  Payload = Encapsulated UDP Payload
-
-           <--------  DATAGRAM
-                        Quarter Stream ID = 11
-                        Context ID = 0
-                        Payload = Encapsulated UDP Payload
-
-STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_DATAGRAM_CONTEXT
-  Context ID = 2
-  Datagram Format Type = UDP_PAYLOAD_WITH_TIMESTAMP
-  Datagram Format Additional Data = ""
-
-DATAGRAM                       -------->
-  Quarter Stream ID = 11
+  Encoded Stream ID = 23
   Context ID = 2
   Payload = Encapsulated UDP Payload With Timestamp
+
+           <--------  DATAGRAM
+                        Encoded Stream ID = 22
+                        Payload = Encapsulated UDP Payload
 ~~~
 
 ### Successful Optimistic
 
 In this instance, the client does not wish to spend a round trip waiting to
-learn whether the server supports datagram contexts. It registers its context
-optimistically in such a way that the server will react well whether it
-supports contexts or not. In this case, the server does support datagram
-contexts.
+learn whether the server supports the non-default contexts for the
+timestamp extension. It registers its context optimistically in such a way
+that the server will handle its datagram only if the extension is supported.
+In this case, the server does support the extension.
 
 ~~~
 Client                                             Server
@@ -970,47 +664,36 @@ STREAM(44): HEADERS            -------->
   :scheme = https
   :path = /target.example.org/443/
   :authority = proxy.example.org:443
-  Sec-Use-Datagram-Contexts = ?1
+  Sec-UDP-Timestamps = ?1
 
 STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_DATAGRAM
-  Datagram Format Type = UDP_PAYLOAD
-  Datagram Format Additional Data = ""
+  Capsule Type = REGISTER_UDP_WITH_TIMESTAMP_CONTEXT
+  Context ID = 2
 
-STREAM(44): DATA               -------->
-  Capsule Type = DATAGRAM
-  Payload = Encapsulated UDP Payload
+DATAGRAM                        -------->
+  Encoded Stream ID = 23
+  Context ID = 2
+  Payload = Encapsulated UDP Payload With Timestamp
 
            <--------  STREAM(44): HEADERS
                         :status = 200
-                        Sec-Use-Datagram-Contexts = ?1
+                        Sec-UDP-Timestamps = ?1
 
-/* Datagram contexts are in use on this stream */
+/* UDP timestamps are supported on this stream */
 
            <--------  DATAGRAM
-                        Quarter Stream ID = 11
-                        Context ID = 0
+                        Encoded Stream ID = 22
                         Payload = Encapsulated UDP Payload
-
-STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_DATAGRAM_CONTEXT
-  Context ID = 2
-  Datagram Format Type = UDP_PAYLOAD_WITH_TIMESTAMP
-  Datagram Format Additional Data = ""
-
-DATAGRAM                       -------->
-  Quarter Stream ID = 11
-  Context ID = 2
-  Payload = Encapsulated UDP Payload With Timestamp
 ~~~
 
 ### Optimistic but Unsupported
 
 In this instance, the client does not wish to spend a round trip waiting to
-learn whether the server supports datagram contexts. It registers its context
-optimistically in such a way that the server will react well whether it
-supports contexts or not. In this case, the server does not support datagram
-contexts.
+learn whether the server supports the non-default contexts for the
+timestamp extension. It registers its context optimistically in such a way
+that the server will handle its datagram only if the extension is supported.
+In this case, the server does not support the extension, and the client
+re-transmits its datagram after learning this.
 
 ~~~
 Client                                             Server
@@ -1024,26 +707,26 @@ STREAM(44): HEADERS            -------->
   Sec-Use-Datagram-Contexts = ?1
 
 STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_DATAGRAM
-  Datagram Format Type = UDP_PAYLOAD
-  Datagram Format Additional Data = ""
+  Capsule Type = REGISTER_UDP_WITH_TIMESTAMP_CONTEXT
+  Context ID = 2
 
-STREAM(44): DATA               -------->
-  Capsule Type = DATAGRAM
-  Payload = Encapsulated UDP Payload
+DATAGRAM                        -------->
+  Encoded Stream ID = 23
+  Context ID = 2
+  Payload = Encapsulated UDP Payload With Timestamp
 
            <--------  STREAM(44): HEADERS
                         :status = 200
 
-/* Datagram contexts are not in use on this stream */
+/* UDP timestamps are not supported on this stream */
+
+DATAGRAM                        -------->
+  Encoded Stream ID = 22
+  Payload = Encapsulated UDP Payload
 
            <--------  DATAGRAM
-                        Quarter Stream ID = 11
+                        Encoded Stream ID = 22
                         Payload = Encapsulated UDP Payload
-
-DATAGRAM                       -------->
-  Quarter Stream ID = 11
-  Payload = Encapsulated UDP Payload
 ~~~
 
 
@@ -1058,31 +741,23 @@ STREAM(44): HEADERS            -------->
   :scheme = https
   :path = /
   :authority = proxy.example.org:443
-  Sec-Use-Datagram-Contexts = ?1
+  Sec-Use-IP-Compression = ?1
 
            <--------  STREAM(44): HEADERS
                         :status = 200
-                        Sec-Use-Datagram-Contexts = ?1
+                        Sec-Use-IP-Compression = ?1
 
 /* Exchange CONNECT-IP configuration information. */
 
-STREAM(44): DATA                -------->
-  Capsule Type = REGISTER_DATAGRAM_CONTEXT
-  Context ID = 0
-  Datagram Format Type = IP_PACKET
-  Datagram Format Additional Data = ""
-
 DATAGRAM                       -------->
-  Quarter Stream ID = 11
-  Context ID = 0
+  Encoded Stream ID = 22
   Payload = Encapsulated IP Packet
 
 /* Endpoint happily exchange encapsulated IP packets */
-/* using Quarter Stream ID 11 and Context ID 0.      */
+/* using Encoded Stream ID 22 and Context ID 0.      */
 
 DATAGRAM                       -------->
-  Quarter Stream ID = 11
-  Context ID = 0
+  Encoded Stream ID = 22
   Payload = Encapsulated IP Packet
 
 /* After performing some analysis on traffic patterns, */
@@ -1090,13 +765,12 @@ DATAGRAM                       -------->
 
 
 STREAM(44): DATA                -------->
-  Capsule Type = REGISTER_DATAGRAM_CONTEXT
+  Capsule Type = REGISTER_IP_COMPRESSION_CONTEXT
   Context ID = 2
-  Datagram Format Type = COMPRESSED_IP_PACKET
-  Datagram Format Additional Data = "192.0.2.6,192.0.2.7"
+  Compression Tuple = "192.0.2.6,192.0.2.7"
 
 DATAGRAM                       -------->
-  Quarter Stream ID = 11
+  Encoded Stream ID = 23
   Context ID = 2
   Payload = Compressed IP Packet
 ~~~
@@ -1114,11 +788,6 @@ STREAM(44): HEADERS            -------->
   :path = /hello
   :authority = webtransport.example.org:443
   Origin = https://www.example.org:443
-
-STREAM(44): DATA                -------->
-  Capsule Type = REGISTER_DATAGRAM
-  Datagram Format Type = WEBTRANSPORT_DATAGRAM
-  Datagram Format Additional Data = ""
 
            <--------  STREAM(44): HEADERS
                         :status = 200

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -614,47 +614,11 @@ UDP payload. A new header, Sec-UDP-Timestamps, indicates support for the
 extension.
 
 
-### With Delay
+### Extension Supported
 
-In this instance, the client prefers to wait a round trip to learn whether the
-server supports non-default datagram contexts for the timestamp extension.
-
-~~~
-Client                                             Server
-
-STREAM(44): HEADERS            -------->
-  :method = CONNECT
-  :protocol = connect-udp
-  :scheme = https
-  :path = /target.example.org/443/
-  :authority = proxy.example.org:443
-  Sec-UDP-Timestamps = ?1
-
-           <--------  STREAM(44): HEADERS
-                        :status = 200
-                        Sec-UDP-Timestamps = ?1
-
-STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_UDP_WITH_TIMESTAMP_CONTEXT
-  Context ID = 2
-
-DATAGRAM                        -------->
-  Encoded Stream ID = 23
-  Context ID = 2
-  Payload = Encapsulated UDP Payload With Timestamp
-
-           <--------  DATAGRAM
-                        Encoded Stream ID = 22
-                        Payload = Encapsulated UDP Payload
-~~~
-
-### Successful Optimistic
-
-In this instance, the client does not wish to spend a round trip waiting to
-learn whether the server supports the non-default contexts for the
-timestamp extension. It registers its context optimistically in such a way
-that the server will handle its datagram only if the extension is supported.
-In this case, the server does support the extension.
+In this instance, the server supports non-default datagram contexts for the
+timestamp extension. The client registers a context for UDP payloads
+with timestamps once it learns that the extension is supported.
 
 ~~~
 Client                                             Server
@@ -667,14 +631,9 @@ STREAM(44): HEADERS            -------->
   :authority = proxy.example.org:443
   Sec-UDP-Timestamps = ?1
 
-STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_UDP_WITH_TIMESTAMP_CONTEXT
-  Context ID = 2
-
 DATAGRAM                        -------->
-  Encoded Stream ID = 23
-  Context ID = 2
-  Payload = Encapsulated UDP Payload With Timestamp
+  Encoded Stream ID = 22
+  Payload = Encapsulated UDP Payload
 
            <--------  STREAM(44): HEADERS
                         :status = 200
@@ -682,19 +641,26 @@ DATAGRAM                        -------->
 
 /* UDP timestamps are supported on this stream */
 
+STREAM(44): DATA               -------->
+  Capsule Type = REGISTER_UDP_WITH_TIMESTAMP_CONTEXT
+  Context ID = 2
+
+DATAGRAM                        -------->
+  Encoded Stream ID = 23
+  Context ID = 2
+  Payload = Encapsulated UDP Payload With Timestamp
+
            <--------  DATAGRAM
                         Encoded Stream ID = 22
                         Payload = Encapsulated UDP Payload
 ~~~
 
-### Optimistic but Unsupported
 
-In this instance, the client does not wish to spend a round trip waiting to
-learn whether the server supports the non-default contexts for the
-timestamp extension. It registers its context optimistically in such a way
-that the server will handle its datagram only if the extension is supported.
-In this case, the server does not support the extension, and the client
-re-transmits its datagram after learning this.
+### Extension Unsupported
+
+In this instance, the server does not support non-default datagram contexts
+for the timestamp extension.
+
 
 ~~~
 Client                                             Server
@@ -705,25 +671,16 @@ STREAM(44): HEADERS            -------->
   :scheme = https
   :path = /target.example.org/443/
   :authority = proxy.example.org:443
-  Sec-Use-Datagram-Contexts = ?1
-
-STREAM(44): DATA               -------->
-  Capsule Type = REGISTER_UDP_WITH_TIMESTAMP_CONTEXT
-  Context ID = 2
+  Sec-UDP-Timestamps = ?1
 
 DATAGRAM                        -------->
-  Encoded Stream ID = 23
-  Context ID = 2
-  Payload = Encapsulated UDP Payload With Timestamp
+  Encoded Stream ID = 22
+  Payload = Encapsulated UDP Payload
 
            <--------  STREAM(44): HEADERS
                         :status = 200
 
 /* UDP timestamps are not supported on this stream */
-
-DATAGRAM                        -------->
-  Encoded Stream ID = 22
-  Payload = Encapsulated UDP Payload
 
            <--------  DATAGRAM
                         Encoded Stream ID = 22

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -406,9 +406,9 @@ DPLPMTUD.
 
 ## Registering Datagram Contexts with Capsules {#register-capsules}
 
-Methods or protocols that support multiple datagram payload formats or
-separate types of datagrams can differentiate them using datagram contexts
-({{datagram-contexts}}).
+HTTP Methods or protocols enabled by HTTP Upgrade Tokens that support
+multiple datagram payload formats or separate types of datagrams can
+differentiate them using datagram contexts ({{datagram-contexts}}).
 
 Such protocols can define a new Capsule type that is used to register
 a context ID with the peer endpoint.
@@ -499,7 +499,7 @@ This document will request IANA to register the following entry in the
 
 | Setting Name |   Value  | Specification | Default |
 |:-------------|:---------|:--------------|:--------|
-| H3_DATAGRAM  | 0xffd277 | This Document |    0    |
+| H3_DATAGRAM  | 0xffd278 | This Document |    0    |
 {: #iana-setting-table title="New HTTP/3 Settings"}
 
 
@@ -556,8 +556,8 @@ This registry initially contains the following entries:
 
 | Capsule Type                 |   Value   | Specification |
 |:-----------------------------|:----------|:--------------|
-| DATAGRAM                     | 0xff37a1  | This Document |
-| DATAGRAM_WITH_CONTEXT        | 0xff37a2  | This Document |
+| DATAGRAM_WITH_CONTEXT        | 0xff37a4  | This Document |
+| DATAGRAM                     | 0xff37a5  | This Document |
 {: #iana-types-table title="Initial Capsule Types Registry Entries"}
 
 Capsule types with a value of the form 41 * N + 23 for integer values of N are
@@ -610,7 +610,7 @@ uses a different Datagram Format Type that carries a timestamp followed by the
 encapsulated UDP payload. Datagrams on the default context (0) are expected to
 contain UDP payloads, while contexts established with the
 REGISTER_UDP_WITH_TIMESTAMP_CONTEXT capsule include a timestamp along with the
-UDP payload. A new header, Sec-UDP-Timestamps, indicates support for the
+UDP payload. A new header, Sec-Use-UDP-Timestamps, indicates support for the
 extension.
 
 
@@ -629,7 +629,7 @@ STREAM(44): HEADERS            -------->
   :scheme = https
   :path = /target.example.org/443/
   :authority = proxy.example.org:443
-  Sec-UDP-Timestamps = ?1
+  sec-use-udp-timestamps = ?1
 
 DATAGRAM                        -------->
   Encoded Stream ID = 22
@@ -637,7 +637,7 @@ DATAGRAM                        -------->
 
            <--------  STREAM(44): HEADERS
                         :status = 200
-                        Sec-UDP-Timestamps = ?1
+                        sec-use-udp-timestamps = ?1
 
 /* UDP timestamps are supported on this stream */
 
@@ -651,8 +651,9 @@ DATAGRAM                        -------->
   Payload = Encapsulated UDP Payload With Timestamp
 
            <--------  DATAGRAM
-                        Encoded Stream ID = 22
-                        Payload = Encapsulated UDP Payload
+                        Encoded Stream ID = 23
+                        Context ID = 2
+                        Payload = Encapsulated UDP Payload With Timestamp
 ~~~
 
 
@@ -671,7 +672,7 @@ STREAM(44): HEADERS            -------->
   :scheme = https
   :path = /target.example.org/443/
   :authority = proxy.example.org:443
-  Sec-UDP-Timestamps = ?1
+  sec-use-udp-timestamps = ?1
 
 DATAGRAM                        -------->
   Encoded Stream ID = 22
@@ -699,11 +700,11 @@ STREAM(44): HEADERS            -------->
   :scheme = https
   :path = /
   :authority = proxy.example.org:443
-  Sec-Use-IP-Compression = ?1
+  sec-use-ip-compression = ?1
 
            <--------  STREAM(44): HEADERS
                         :status = 200
-                        Sec-Use-IP-Compression = ?1
+                        sec-use-ip-compression = ?1
 
 /* Exchange CONNECT-IP configuration information. */
 
@@ -745,7 +746,7 @@ STREAM(44): HEADERS            -------->
   :method = webtransport
   :path = /hello
   :authority = webtransport.example.org:443
-  Origin = https://www.example.org:443
+  origin = https://www.example.org:443
 
            <--------  STREAM(44): HEADERS
                         :status = 200

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -609,7 +609,7 @@ In these examples, the client supports a CONNECT-UDP Timestamp Extension, which
 uses a different Datagram Format Type that carries a timestamp followed by the
 encapsulated UDP payload. Datagrams on the default context (0) are expected to
 contain UDP payloads, while contexts established with the
-REGISTER_UDP_WITH_TIMESTAMP_CONTEXT capsule include a timestamp along with the
+REGISTER_UDP_WITH_TIMESTAMP_CONTEXT capsule include a timestamp followed by the
 UDP payload. A new header, Sec-Use-UDP-Timestamps, indicates support for the
 extension.
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -187,9 +187,10 @@ Context ID:
 
 : A variable-length integer indicating the context ID of the datagram (see
 {{datagram-contexts}}). Whether or not this field is present depends on whether
-the least-significant bit of the Encoded Stream ID, as described above. If the
+the least-significant bit of the Encoded Stream ID is set, as described above. If the
 receiver of a datagram does not support Context IDs, it will drop any datagram
-that contains a context ID.
+that contains a context ID. If the Context ID field is not present, this datagram
+is associated with the default context (which has its Context ID set to 0).
 
 HTTP Datagram Payload:
 


### PR DESCRIPTION
- Remove datagram format registry -- new capsule types can be used instead
- Delegate context ID registration to methods/protocols, which can define new capsule types
- Remove the need for header negotiation to support contexts. Individual methods can define their own headers for negotiation.
- Datagram contexts don't always need to be used, but there's an implicit "context 0" which has a format that must be defined by each method. The presence of a context ID in a datagram is encoded in the "encoded stream ID".

[Rendered view of this PR](https://ietf-wg-masque.github.io/draft-ietf-masque-h3-datagram/tfp/simplify/draft-ietf-masque-h3-datagram.html).