### PR TITLE
all dgrams associated with requests

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -34,10 +34,9 @@ The QUIC DATAGRAM extension provides application protocols running over QUIC
 with a mechanism to send unreliable data while leveraging the security and
 congestion-control properties of QUIC. However, QUIC DATAGRAM frames do not
 provide a means to demultiplex application contexts. This document describes how
-to use QUIC DATAGRAM frames when the application protocol running over QUIC is
-HTTP/3. It associates datagrams with client-initiated bidirectional streams.
-Additionally, this document defines a mechanism to convey datagrams over prior
-versions of HTTP.
+to use QUIC DATAGRAM frames can be used with HTTP/3 by association with HTTP
+requests. Additionally, this document defines a mechanism to convey datagrams
+over prior versions of HTTP.
 
 
 --- middle
@@ -49,10 +48,9 @@ application protocols running over QUIC {{!QUIC=RFC9000}} with a mechanism to
 send unreliable data while leveraging the security and congestion-control
 properties of QUIC. However, QUIC DATAGRAM frames do not provide a means to
 demultiplex application contexts. This document describes how to use QUIC
-DATAGRAM frames when the application protocol running over QUIC is HTTP/3
-{{!H3=I-D.ietf-quic-http}}. It associates datagrams with client-initiated
-bidirectional streams. Additionally, this document defines a mechanism to convey
-datagrams over prior versions of HTTP.
+DATAGRAM frames can be used with HTTP/3 {{!H3=I-D.ietf-quic-http}} by
+association with HTTP requests. Additionally, this document defines a mechanism
+to convey datagrams over prior versions of HTTP.
 
 This document is structured as follows:
 


### PR DESCRIPTION
In Section 2 we start with the statement 

> All HTTP Datagrams are associated with an HTTP request.

So let's just use that clearer description in the abstract and introduction too,