### PR TITLE
Changes to Capsule-Protocol header section

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -261,16 +261,13 @@ When a stream carrying capsules terminates cleanly, if the last capsule on the
 stream was truncated, this MUST be treated as a malformed or incomplete message.
 
 
-## The Capsule-Protocol Header {#hdr}
+## The Capsule-Protocol Header Field {#hdr}
 
-Definitions of new HTTP Upgrade Tokens that use the Capsule Protocol MAY use the
-Capsule-Protocol header field to simplify intermediary processing.
+This document defines the "Capsule-Protocol" header field. It is an Item
+Structured Header {{!RFC8941}}; its value MUST be a Boolean. Its ABNF is:
 
-"Capsule-Protocol" is an Item Structured Header {{!RFC8941}}. Its value MUST be
-a Boolean. Its ABNF is:
-
-~~~
-Capsule-Protocol = sf-boolean parameters
+~~~ abnf
+Capsule-Protocol = sf-item
 ~~~
 
 Endpoints indicate that the Capsule Protocol is in use on the data stream by
@@ -285,6 +282,9 @@ The Capsule-Protocol header field MUST NOT be used on HTTP responses with a
 status code different from 2xx (Successful). This specification does not define
 any parameters for the Capsule-Protocol header field value, but future documents
 MAY define parameters. Receivers MUST ignore unknown parameters.
+
+Definitions of new HTTP Upgrade Tokens that use the Capsule Protocol MAY use the
+Capsule-Protocol header field to simplify intermediary processing.
 
 
 ## The DATAGRAM Capsule {#datagram-capsule}


### PR DESCRIPTION
The HTTP WG is working on a style guide, see https://github.com/httpwg/admin/blob/main/style-guide.md

In line with the style, the reference to structured fields is updated in #147 because it's less contentious. What remains here is probably more so.

First, move the consideration for intermediaries to the bottom of the section. It doesn't seem a leading item to me. 

Then we start the section with a  focus on defining the field itself. The ABNF is probably the bit we'll disagree with. It seems in trying to be specific on the Item type, you've written out the the subcomponents of the ABNF. This is something that is being discussed in the HTTP WG list. Personally I don't like being overly specific in the ABNF because it could be misconstrued as something that is SF-like but not really SF. As far as a generic SF parser goes, it will only validate that the thing is an Item and it will be up to higher layers to apply additional constraints on that. Parameters can always appear with an Item on the wire, whether an application allows that or not is a different matter. Restating ABNF makes this topic more thorny.