### PR TITLE
use bcp14-tagged macro

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -69,10 +69,7 @@ This document is structured as follows:
 
 ## Conventions and Definitions {#defs}
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
-document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
+{::boilerplate bcp14-tagged}
 
 
 # Multiplexing


### PR DESCRIPTION
It's shorter and apparently the tagging is what is now required later on in the RFC process anyway.