### PR TITLE
direct ref to varints

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -138,7 +138,8 @@ negotiation mechanism and semantics for HTTP Datagrams.
 
 When used with HTTP/3, the Datagram Data field of QUIC DATAGRAM frames uses the
 following format (using the notation from the "Notational Conventions" section
-of {{!QUIC=RFC9000}}):
+of {{!QUIC=RFC9000}}). Variable-length integers are encoded in a format defined
+in {{Section 16 of QUIC}}.
 
 ~~~
 HTTP/3 Datagram {


### PR DESCRIPTION
Nit from AD review: Rather than indirectly reference varints through the QUIC notational conventions section, this adds a direct reference to where varints are defined.