### PR TITLE
Data streams are subject to underlying layer's flow control

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -474,9 +474,10 @@ into memory.
 
 Since QUIC DATAGRAM frames are required to fit within a QUIC packet,
 implementations that reencode DATAGRAM capsules into QUIC DATAGRAM frames might
-be tempted to let the capsule data accumulate in the data stream until they have received a complete DATAGRAM capsule. This approach
-can consume flow control in underlying layers, which might lead to deadlocks if
-the capsule data exhausts the flow control window.
+be tempted to let the capsule data accumulate in the data stream until they have
+received a complete DATAGRAM capsule. This approach can consume flow control in
+underlying layers, which might lead to deadlocks if the capsule data exhausts
+the flow control window.
 
 Note that it is possible for an HTTP extension to use HTTP Datagrams without
 using the Capsule Protocol. For example, if an HTTP extension that uses HTTP

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -359,9 +359,9 @@ codes 204 (No Content), 205 (Reset Content), and 206 (Partial Content) MUST NOT
 be sent on responses that use the Capsule Protocol. A receiver that observes a
 violation of these requirements MUST treat the HTTP message as malformed.
 
-Receivers of capsules can read them read them from the data stream in a
-streaming fashion. In some implementations, streaming can help to more rapidly
-free up consumed flow control capacity in the underlying layers.
+Receivers of capsules can read them them from the data stream in a streaming
+fashion. In some implementations, streaming can help to more rapidly free up
+consumed flow control capacity in the underlying layers.
 
 
 ## Error Handling

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -290,8 +290,9 @@ Data streams can be prioritized using any means suited to stream or request
 prioritization. For example, see {{Section 11 of
 ?PRIORITY=I-D.ietf-httpbis-priority}}.
 
-Data streams are subject to the flow control mechanisms of the underlying
-layers (for example, HTTP/2 stream flow control, HTTP/2 connection flow control, and TCP flow control).
+Data streams are subject to the flow control mechanisms of the underlying layers
+(for example, HTTP/2 stream flow control, HTTP/2 connection flow control, and
+TCP flow control).
 
 
 ## The Capsule Protocol {#capsule-protocol}

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -291,7 +291,7 @@ prioritization. For example, see {{Section 11 of
 ?PRIORITY=I-D.ietf-httpbis-priority}}.
 
 Data streams are subject to the flow control mechanisms of the underlying
-layers.
+layers (for example, HTTP/2 stream flow control, HTTP/2 connection flow control, and TCP flow control).
 
 
 ## The Capsule Protocol {#capsule-protocol}
@@ -471,11 +471,11 @@ DATAGRAM capsule has a length that is known to be so large as to not be usable,
 the implementation SHOULD discard the capsule without buffering its contents
 into memory.
 
-Since QUIC DATAGRAM frames must be sent completely within a QUIC packet,
+Since QUIC DATAGRAM frames are required to fit within a QUIC packet,
 implementations that reencode DATAGRAM capsules into QUIC DATAGRAM frames might
 be tempted to let the capsule data accumulate in the data stream. This approach
 can consume flow control in underlying layers, which might lead to deadlocks if
-the capsule length is larger than the flow control window.
+the capsule data exhausts the flow control window.
 
 Note that it is possible for an HTTP extension to use HTTP Datagrams without
 using the Capsule Protocol. For example, if an HTTP extension that uses HTTP

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -474,7 +474,7 @@ into memory.
 
 Since QUIC DATAGRAM frames are required to fit within a QUIC packet,
 implementations that reencode DATAGRAM capsules into QUIC DATAGRAM frames might
-be tempted to let the capsule data accumulate in the data stream. This approach
+be tempted to let the capsule data accumulate in the data stream until they have received a complete DATAGRAM capsule. This approach
 can consume flow control in underlying layers, which might lead to deadlocks if
 the capsule data exhausts the flow control window.
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -359,9 +359,9 @@ codes 204 (No Content), 205 (Reset Content), and 206 (Partial Content) MUST NOT
 be sent on responses that use the Capsule Protocol. A receiver that observes a
 violation of these requirements MUST treat the HTTP message as malformed.
 
-Receivers of capsules can read them them from the data stream in a streaming
-fashion. In some implementations, streaming can help to more rapidly free up
-consumed flow control capacity in the underlying layers.
+Receivers of capsules can read them from the data stream in a streaming fashion.
+In some implementations, streaming can help to more rapidly free up consumed
+flow control capacity in the underlying layers.
 
 
 ## Error Handling

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -290,6 +290,9 @@ Data streams can be prioritized using any means suited to stream or request
 prioritization. For example, see {{Section 11 of
 ?PRIORITY=I-D.ietf-httpbis-priority}}.
 
+Data streams are subject to the flow control mechanisms of the underlying
+layers.
+
 
 ## The Capsule Protocol {#capsule-protocol}
 
@@ -355,6 +358,10 @@ Content-Type, or Transfer-Encoding header fields. Additionally, HTTP status
 codes 204 (No Content), 205 (Reset Content), and 206 (Partial Content) MUST NOT
 be sent on responses that use the Capsule Protocol. A receiver that observes a
 violation of these requirements MUST treat the HTTP message as malformed.
+
+Receivers of capsules can read them read them from the data stream in a
+streaming fashion. In some implementations, streaming can help to more rapidly
+free up consumed flow control capacity in the underlying layers.
 
 
 ## Error Handling
@@ -463,6 +470,12 @@ take those limits into account when parsing DATAGRAM capsules: if an incoming
 DATAGRAM capsule has a length that is known to be so large as to not be usable,
 the implementation SHOULD discard the capsule without buffering its contents
 into memory.
+
+Since QUIC DATAGRAM frames must be sent completely within a QUIC packet,
+implementations that reencode DATAGRAM capsules into QUIC DATAGRAM frames might
+be tempted to let the capsule data accumulate in the data stream. This approach
+can consume flow control in underlying layers, which might lead to deadlocks if
+the capsule length is larger than the flow control window.
 
 Note that it is possible for an HTTP extension to use HTTP Datagrams without
 using the Capsule Protocol. For example, if an HTTP extension that uses HTTP

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -360,9 +360,10 @@ codes 204 (No Content), 205 (Reset Content), and 206 (Partial Content) MUST NOT
 be sent on responses that use the Capsule Protocol. A receiver that observes a
 violation of these requirements MUST treat the HTTP message as malformed.
 
-Receivers of capsules can read them from the data stream in a streaming fashion.
-In some implementations, streaming can help to more rapidly free up consumed
-flow control capacity in the underlying layers.
+When processing capsules, a receiver might tempted to accumulate the full length
+of the capsule value in the data stream before handling it. This approach can
+consume flow control in underlying layers, which might lead to deadlocks if the
+capsule data exhausts the flow control window.
 
 
 ## Error Handling
@@ -474,10 +475,8 @@ into memory.
 
 Since QUIC DATAGRAM frames are required to fit within a QUIC packet,
 implementations that reencode DATAGRAM capsules into QUIC DATAGRAM frames might
-be tempted to let the capsule data accumulate in the data stream until they have
-received a complete DATAGRAM capsule. This approach can consume flow control in
-underlying layers, which might lead to deadlocks if the capsule data exhausts
-the flow control window.
+be tempted to accumulate the entire capsule before reencoding it. This can cause
+flow control problems; see {{capsule-protocol}}.
 
 Note that it is possible for an HTTP extension to use HTTP Datagrams without
 using the Capsule Protocol. For example, if an HTTP extension that uses HTTP


### PR DESCRIPTION
This adds a few statements through the text that explains that data
streams are subject to any flow control provided by layers lower down.
Wih that in mind, the potential for problem deadlocks should be clearer
when we state it.

Fixes #199
