### PR TITLE
Be clearer about message error vs. stream errors

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -373,7 +373,7 @@ stream management frames (RST_STREAM, WINDOW_UPDATE, and PRIORITY) are
 permitted; other frame types MUST NOT be sent and MUST be treated as a stream
 error ({{Section 5.4.2 of H2}}) if received. In HTTP/3, only DATA frames are
 permitted; other frame types MUST NOT be sent and MUST be treated as connection
-error o)f type H3_FRAME_UNEXPECTED ({{Section 8 of H3}}) if received. In both
+error of type H3_FRAME_UNEXPECTED ({{Section 8 of H3}}) if received. In both
 cases, extension frame types MAY be used if a specifically permitted by the
 definition of the extension.
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -374,7 +374,7 @@ permitted; other frame types MUST NOT be sent and MUST be treated as a stream
 error ({{Section 5.4.2 of H2}}) if received. In HTTP/3, only DATA frames are
 permitted; other frame types MUST NOT be sent and MUST be treated as connection
 error of type H3_FRAME_UNEXPECTED ({{Section 8 of H3}}) if received. In both
-cases, extension frame types MAY be used if a specifically permitted by the
+cases, extension frame types MAY be used if specifically permitted by the
 definition of the extension.
 
 Each capsule's payload MUST contain exactly the fields identified in its

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -367,7 +367,7 @@ in {{Section 4.1.3 of H3}}. For HTTP/2, the handling of malformed messages is
 described in {{Section 8.1.1 of H2}}. For HTTP/1.1, the handling of incomplete
 messages is described in {{Section 8 of H1}}.
 
-For HTTP/2 and HTTP/3, once a both endpoints agree to use the Capsule Protocol,
+For HTTP/2 and HTTP/3, once both endpoints agree to use the Capsule Protocol,
 the frame usage requirements of the stream change. In HTTP/2, only DATA or
 stream management frames (RST_STREAM, WINDOW_UPDATE, and PRIORITY) are
 permitted; other frame types MUST NOT be sent and MUST be treated as a stream

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -359,23 +359,18 @@ violation of these requirements MUST treat the HTTP message as malformed.
 
 ## Error Handling
 
-Unless otherwise stated, Capsule Protocol endpoints are expected to apply the
-same message format rules as the underlying HTTP version. When a receiver
-encounters a processing error, it MUST be treated as if it were a malformed or
-incomplete message. For HTTP/3, the handling of malformed messages is described
+When a receiver encounters an error processing the Capsule Protocol, the receiver
+MUST treat it as if it had received a malformed or incomplete HTTP message.
+For HTTP/3, the handling of malformed messages is described
 in {{Section 4.1.3 of H3}}. For HTTP/2, the handling of malformed messages is
 described in {{Section 8.1.1 of H2}}. For HTTP/1.1, the handling of incomplete
 messages is described in {{Section 8 of H1}}.
 
-For HTTP/2 and HTTP/3, once both endpoints agree to use the Capsule Protocol,
-the frame usage requirements of the stream change. In HTTP/2, only DATA or
-stream management frames (RST_STREAM, WINDOW_UPDATE, and PRIORITY) are
-permitted; other frame types MUST NOT be sent and MUST be treated as a stream
-error ({{Section 5.4.2 of H2}}) if received. In HTTP/3, only DATA frames are
-permitted; other frame types MUST NOT be sent and MUST be treated as connection
-error of type H3_FRAME_UNEXPECTED ({{Section 8 of H3}}) if received. In both
-cases, extension frame types MAY be used if specifically permitted by the
-definition of the extension.
+Since the Capsule Protocol only applies to definitions of new HTTP Upgrade
+Tokens, in HTTP/2 and HTTP/3 it can only be used with the CONNECT method.
+Therefore, once both endpoints agree to use the Capsule Protocol, the frame
+usage requirements of the stream change as specified in {{Section 8.5 of H2}}
+and {{Section 4.2 of H3}}.
 
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -350,6 +350,12 @@ By virtue of the definition of the data stream:
   do not carry HTTP content. A future extension MAY define a new capsule type to
   carry HTTP content.
 
+Since the Capsule Protocol only applies to definitions of new HTTP Upgrade
+Tokens, in HTTP/2 and HTTP/3 it can only be used with the CONNECT method.
+Therefore, once both endpoints agree to use the Capsule Protocol, the frame
+usage requirements of the stream change as specified in {{Section 8.5 of H2}}
+and {{Section 4.2 of H3}}.
+
 The Capsule Protocol MUST NOT be used with messages that contain Content-Length,
 Content-Type, or Transfer-Encoding header fields. Additionally, HTTP status
 codes 204 (No Content), 205 (Reset Content), and 206 (Partial Content) MUST NOT
@@ -359,18 +365,12 @@ violation of these requirements MUST treat the HTTP message as malformed.
 
 ## Error Handling
 
-When a receiver encounters an error processing the Capsule Protocol, the receiver
-MUST treat it as if it had received a malformed or incomplete HTTP message.
-For HTTP/3, the handling of malformed messages is described
-in {{Section 4.1.3 of H3}}. For HTTP/2, the handling of malformed messages is
+When a receiver encounters an error processing the Capsule Protocol, the
+receiver MUST treat it as if it had received a malformed or incomplete HTTP
+message. For HTTP/3, the handling of malformed messages is described in
+{{Section 4.1.3 of H3}}. For HTTP/2, the handling of malformed messages is
 described in {{Section 8.1.1 of H2}}. For HTTP/1.1, the handling of incomplete
 messages is described in {{Section 8 of H1}}.
-
-Since the Capsule Protocol only applies to definitions of new HTTP Upgrade
-Tokens, in HTTP/2 and HTTP/3 it can only be used with the CONNECT method.
-Therefore, once both endpoints agree to use the Capsule Protocol, the frame
-usage requirements of the stream change as specified in {{Section 8.5 of H2}}
-and {{Section 4.2 of H3}}.
 
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -380,8 +380,9 @@ definition of the extension.
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the
 identified fields or a capsule payload that terminates before the end of the
-identified fields MUST be treated as a malformed or incomplete message. In
-particular, redundant length encodings MUST be verified to be self-consistent.
+identified fields MUST be treated as it if were a malformed or incomplete
+message. In particular, redundant length encodings MUST be verified to be
+self-consistent.
 
 If the receive side of a stream carrying capsules is terminated cleanly (for
 example, in HTTP/3 this is defined as receiving a QUIC STREAM frame with the FIN

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -359,12 +359,23 @@ violation of these requirements MUST treat the HTTP message as malformed.
 
 ## Error Handling
 
-When an error occurs in processing the Capsule Protocol, the receiver MUST treat
-the message as malformed or incomplete, according to the underlying transport
-protocol. For HTTP/3, the handling of malformed messages is described in
-{{Section 4.1.3 of H3}}. For HTTP/2, the handling of malformed messages is
+Unless otherwise stated, Capsule Protocol endpoints are expected to apply the
+same message format rules as the underlying HTTP version. When a receiver
+encounters a processing error, it MUST be treated as if it were a malformed or
+incomplete message. For HTTP/3, the handling of malformed messages is described
+in {{Section 4.1.3 of H3}}. For HTTP/2, the handling of malformed messages is
 described in {{Section 8.1.1 of H2}}. For HTTP/1.1, the handling of incomplete
 messages is described in {{Section 8 of H1}}.
+
+For HTTP/2 and HTTP/3, once a both endpoints agree to use the Capsule Protocol,
+the frame usage requirements of the stream change. In HTTP/2, only DATA or
+stream management frames (RST_STREAM, WINDOW_UPDATE, and PRIORITY) are
+permitted; other frame types MUST NOT be sent and MUST be treated as a stream
+error ({{Section 5.4.2 of H2}}) if received. In HTTP/3, only DATA frames are
+permitted; other frame types MUST NOT be sent and MUST be treated as connection
+error o)f type H3_FRAME_UNEXPECTED ({{Section 8 of H3}}) if received. In both
+cases, extension frame types MAY be used if a specifically permitted by the
+definition of the extension.
 
 Each capsule's payload MUST contain exactly the fields identified in its
 description. A capsule payload that contains additional bytes after the
@@ -375,7 +386,7 @@ particular, redundant length encodings MUST be verified to be self-consistent.
 If the receive side of a stream carrying capsules is terminated cleanly (for
 example, in HTTP/3 this is defined as receiving a QUIC STREAM frame with the FIN
 bit set) and the last capsule on the stream was truncated, this MUST be treated
-as a malformed or incomplete message.
+as if it were a malformed or incomplete message.
 
 
 ## The Capsule-Protocol Header Field {#hdr}


### PR DESCRIPTION
Explicitly replicates parts of H2 and H3 CONNECT stream definition to
make it clear what frame types are/are not allowed on a stream.

Mostly anything else can't happen but if it does, approach error
handling _as if it were like_ a malformed message (I.e whether to
terminate the stream or whatever).

Fixes #200