### PR TITLE
Addressing various style nits

### DIFF
--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -113,9 +113,6 @@ necessary.
 In this document, the term "intermediary" refers to an HTTP intermediary as
 defined in {{Section 3.7 of HTTP}}.
 
-This document uses the following terminology from {{Section 3 of
-!STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing: Item.
-
 
 # HTTP Datagrams {#datagrams}
 
@@ -358,10 +355,10 @@ be sent on responses that use the Capsule Protocol. A receiver that observes a
 violation of these requirements MUST treat the HTTP message as malformed.
 
 When processing Capsules, a receiver might be tempted to accumulate the full
-length of the Capsule value in the data stream before handling it. This approach
-SHOULD be avoided because it can consume flow control in underlying layers, and
-that might lead to deadlocks if the Capsule data exhausts the flow control
-window.
+length of the Capsule Value field in the data stream before handling it. This
+approach SHOULD be avoided because it can consume flow control in underlying
+layers, and that might lead to deadlocks if the Capsule data exhausts the flow
+control window.
 
 
 ## Error Handling
@@ -388,12 +385,12 @@ as if it were a malformed or incomplete message.
 
 ## The Capsule-Protocol Header Field {#hdr}
 
-The "Capsule-Protocol" header field is an Item; see {{Section 3.3 of
-!STRUCTURED-FIELDS=RFC8941}}. Its value MUST be a Boolean; any other value type
-MUST be handled as if the field were not present by recipients (for example, if
-this field is included multiple times, its type will become a List and the field
-will be ignored). This document does not define any parameters for the
-Capsule-Protocol header field value, but future documents might define
+The "Capsule-Protocol" header field is an Item Structured Field; see {{Section
+3.3 of !STRUCTURED-FIELDS=RFC8941}}. Its value MUST be a Boolean; any other
+value type MUST be handled as if the field were not present by recipients (for
+example, if this field is included multiple times, its type will become a List
+and the field will be ignored). This document does not define any parameters for
+the Capsule-Protocol header field value, but future documents might define
 parameters. Receivers MUST ignore unknown parameters.
 
 Endpoints indicate that the Capsule Protocol is in use on a data stream by
@@ -503,7 +500,7 @@ is not accessible from Web Platform APIs (such as those commonly accessed via
 JavaScript in web browsers).
 
 Definitions of new HTTP upgrade tokens that use the Capsule Protocol need to
-perform a security analysis that considers the impact of HTTP Datagrams and
+include a security analysis that considers the impact of HTTP Datagrams and
 Capsules in the context of their protocol.
 
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -326,7 +326,7 @@ An intermediary can identify the use of the Capsule Protocol either through the
 presence of the Capsule-Protocol header field ({{hdr}}) or by understanding the
 chosen HTTP Upgrade token.
 
-Because new protocols or extensions might define new capsule types,
+Because new protocols or extensions might define new Capsule Types,
 intermediaries that wish to allow for future extensibility SHOULD forward
 capsules without modification unless the definition of the Capsule Type in use
 specifies additional intermediary processing. One such Capsule Type is the
@@ -342,7 +342,7 @@ By virtue of the definition of the data stream:
   (Successful) or 101 (Switching Protocols) status code.
 
 * When the Capsule Protocol is in use, the associated HTTP request and response
-  do not carry HTTP content. A future extension MAY define a new capsule type to
+  do not carry HTTP content. A future extension MAY define a new Capsule Type to
   carry HTTP content.
 
 The Capsule Protocol only applies to definitions of new HTTP upgrade tokens;
@@ -415,7 +415,7 @@ upgrade tokens that use the Capsule Protocol MAY alter this recommendation.
 
 ## The DATAGRAM Capsule {#datagram-capsule}
 
-This document defines the DATAGRAM (0x00) capsule type. This capsule allows HTTP
+This document defines the DATAGRAM (0x00) Capsule Type. This capsule allows HTTP
 Datagrams to be sent on a stream using the Capsule Protocol. This is
 particularly useful when HTTP is running over a transport that does not support
 the QUIC DATAGRAM frame.
@@ -597,12 +597,12 @@ Comments:
 
 ## Capsule Types {#iana-types}
 
-This document establishes a registry for HTTP capsule type codes. The "HTTP
+This document establishes a registry for HTTP Capsule Type codes. The "HTTP
 Capsule Types" registry governs a 62-bit space and operates under the QUIC
 registration policy documented in {{Section 22.1 of QUIC}}. This new registry
 includes the common set of fields listed in {{Section 22.1.1 of QUIC}}. In
 addition to those common fields, all registrations in this registry MUST include
-a "Capsule Type" field that contains a short name or label for the capsule type.
+a "Capsule Type" field that contains a short name or label for the Capsule Type.
 
 Permanent registrations in this registry are assigned using the Specification
 Required policy ({{Section 4.6 of !IANA-POLICY=RFC8126}}), except for values
@@ -611,7 +611,7 @@ Standards Action or IESG Approval as defined in {{Sections 4.9 and 4.10 of
 IANA-POLICY}}.
 
 Capsule types with a value of the form 0x29 * N + 0x17 for integer values of N
-are reserved to exercise the requirement that unknown capsule types be ignored.
+are reserved to exercise the requirement that unknown Capsule Types be ignored.
 These capsules have no semantics and can carry arbitrary values. These values
 MUST NOT be assigned by IANA and MUST NOT appear in the listing of assigned
 values.

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -269,7 +269,7 @@ upgraded (i.e., 101).
 In HTTP/1.x, the data stream consists of all bytes on the connection that follow
 the blank line that concludes either the request header section or the final
 response header section. As a result, only the last HTTP request on an HTTP/1.x
-connection can start the capsule protocol.
+connection can start the Capsule Protocol.
 
 In HTTP/2 and HTTP/3, the data stream of a given HTTP request consists of all
 bytes sent in DATA frames with the corresponding stream ID.
@@ -322,7 +322,7 @@ Capsule Value:
 : The payload of this capsule. Its semantics are determined by the value of the
 Capsule Type field.
 
-An intermediary can identify the use of the capsule protocol either through the
+An intermediary can identify the use of the Capsule Protocol either through the
 presence of the Capsule-Protocol header field ({{hdr}}) or by understanding the
 chosen HTTP Upgrade token.
 
@@ -552,7 +552,7 @@ Name:
 : H3_DATAGRAM_ERROR
 
 Description:
-: Datagram or capsule protocol parse error
+: Datagram or Capsule Protocol parse error
 
 Status:
 : permanent

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -386,8 +386,8 @@ as if it were a malformed or incomplete message.
 ## The Capsule-Protocol Header Field {#hdr}
 
 The "Capsule-Protocol" header field is an Item Structured Field; see {{Section
-3.3 of !STRUCT-FIELD=RFC8941}}. Its value MUST be a Boolean; any other value
-type MUST be handled as if the field were not present by recipients (for
+3.3 of !STRUCTURED-FIELDS=RFC8941}}. Its value MUST be a Boolean; any other
+value type MUST be handled as if the field were not present by recipients (for
 example, if this field is included multiple times, its type will become a List
 and the field will be ignored). This document does not define any parameters for
 the Capsule-Protocol header field value, but future documents might define

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -242,14 +242,14 @@ using the Capsule Protocol; see {{datagram-capsule}}.
 
 # Capsules {#capsule}
 
-One mechanism to extend HTTP is to introduce new HTTP Upgrade Tokens; see
+One mechanism to extend HTTP is to introduce new HTTP upgrade tokens; see
 {{Section 16.7 of HTTP}}. In HTTP/1.x, these tokens are used via the Upgrade
 mechanism; see {{Section 7.8 of HTTP}}. In HTTP/2 and HTTP/3, these tokens are
 used via the Extended CONNECT mechanism; see {{?EXT-CONNECT2=RFC8441}} and
 {{?EXT-CONNECT3=RFC9220}}.
 
 This specification introduces the Capsule Protocol. The Capsule Protocol is a
-sequence of type-length-value tuples that definitions of new HTTP Upgrade Tokens
+sequence of type-length-value tuples that definitions of new HTTP upgrade tokens
 can choose to use. It allows endpoints to reliably communicate request-related
 information end-to-end on HTTP request streams, even in the presence of HTTP
 intermediaries. The Capsule Protocol can be used to exchange HTTP Datagrams,
@@ -287,7 +287,7 @@ control, and TCP flow control.
 
 ## The Capsule Protocol {#capsule-protocol}
 
-Definitions of new HTTP Upgrade Tokens can state that their associated request's
+Definitions of new HTTP upgrade tokens can state that their associated request's
 data stream uses the Capsule Protocol. If they do so, the contents of the
 associated request's data stream uses the following format:
 
@@ -345,7 +345,7 @@ By virtue of the definition of the data stream:
   do not carry HTTP content. A future extension MAY define a new capsule type to
   carry HTTP content.
 
-The Capsule Protocol only applies to definitions of new HTTP Upgrade Tokens;
+The Capsule Protocol only applies to definitions of new HTTP upgrade tokens;
 thus, in HTTP/2 and HTTP/3, it can only be used with the CONNECT method.
 Therefore, once both endpoints agree to use the Capsule Protocol, the frame
 usage requirements of the stream change as specified in {{Section 8.5 of H2}}
@@ -402,7 +402,7 @@ header field with a false value has the same semantics as when the header is not
 present.
 
 Intermediaries MAY use this header field to allow processing of HTTP Datagrams
-for unknown HTTP Upgrade Tokens. Note that this is only possible for HTTP
+for unknown HTTP upgrade tokens. Note that this is only possible for HTTP
 Upgrade or Extended CONNECT.
 
 The Capsule-Protocol header field MUST NOT be used on HTTP responses with a
@@ -410,7 +410,7 @@ status code that is both different from 101 and outside the 2xx range.
 
 When using the Capsule Protocol, HTTP endpoints SHOULD send the Capsule-Protocol
 header field to simplify intermediary processing. Definitions of new HTTP
-Upgrade Tokens that use the Capsule Protocol MAY alter this recommendation.
+upgrade tokens that use the Capsule Protocol MAY alter this recommendation.
 
 
 ## The DATAGRAM Capsule {#datagram-capsule}
@@ -498,11 +498,11 @@ offer application services that use HTTP Datagrams, it's best for all
 implementations that support this feature to always send this setting; see
 {{setting}}.
 
-Since use of the Capsule Protocol is restricted to new HTTP Upgrade Tokens, it
+Since use of the Capsule Protocol is restricted to new HTTP upgrade tokens, it
 is not accessible from Web Platform APIs (such as those commonly accessed via
 JavaScript in web browsers).
 
-Definitions of new HTTP Upgrade Tokens that use the Capsule Protocol need to
+Definitions of new HTTP upgrade tokens that use the Capsule Protocol need to
 perform a security analysis that considers the impact of HTTP Datagrams and
 Capsules in the context of their protocol.
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -167,8 +167,8 @@ bidirectional stream that this datagram is associated with divided by four (the
 division by four stems from the fact that HTTP requests are sent on
 client-initiated bidirectional streams, which have stream IDs that are divisible
 by four). The largest legal QUIC stream ID value is 2<sup>62</sup>-1, so the
-largest legal value of Quarter Stream ID is 2<sup>60</sup>-1. Receipt of an
-HTTP/3 Datagram that includes a larger value MUST be treated as an HTTP/3
+largest legal value of the Quarter Stream ID field is 2<sup>60</sup>-1. Receipt
+of an HTTP/3 Datagram that includes a larger value MUST be treated as an HTTP/3
 connection error of type H3_DATAGRAM_ERROR (0x33).
 
 HTTP Datagram Payload:
@@ -184,16 +184,16 @@ HTTP/3 Datagrams MUST NOT be sent unless the corresponding stream's send side is
 open. If a datagram is received after the corresponding stream's receive side is
 closed, the received datagrams MUST be silently dropped.
 
-If an HTTP/3 Datagram is received and its Quarter Stream ID maps to a stream
-that has not yet been created, the receiver SHALL either drop that datagram
-silently or buffer it temporarily (on the order of a round trip) while awaiting
-the creation of the corresponding stream.
+If an HTTP/3 Datagram is received and its Quarter Stream ID field maps to a
+stream that has not yet been created, the receiver SHALL either drop that
+datagram silently or buffer it temporarily (on the order of a round trip) while
+awaiting the creation of the corresponding stream.
 
-If an HTTP/3 Datagram is received and its Quarter Stream ID maps to a stream
-that cannot be created due to client-initiated bidirectional stream limits, it
-SHOULD be treated as an HTTP/3 connection error of type H3_ID_ERROR. Generating
-an error is not mandatory because the QUIC stream limit might be unknown to the
-HTTP/3 layer.
+If an HTTP/3 Datagram is received and its Quarter Stream ID field maps to a
+stream that cannot be created due to client-initiated bidirectional stream
+limits, it SHOULD be treated as an HTTP/3 connection error of type H3_ID_ERROR.
+Generating an error is not mandatory because the QUIC stream limit might be
+unknown to the HTTP/3 layer.
 
 Prioritization of HTTP/3 Datagrams is not defined in this document. Future
 extensions MAY define how to prioritize datagrams and MAY define signaling to

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -530,6 +530,9 @@ Change Controller:
 
 Contact:
 : HTTP_WG; HTTP working group; ietf-http-wg@w3.org
+
+Notes:
+: None
 {: spacing="compact"}
 
 
@@ -558,6 +561,9 @@ Change Controller:
 
 Contact:
 : HTTP_WG; HTTP working group; ietf-http-wg@w3.org
+
+Notes:
+: None
 {: spacing="compact"}
 
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -610,7 +610,7 @@ between 0x00 and 0x3f (in hexadecimal; inclusive), which are assigned using
 Standards Action or IESG Approval as defined in {{Sections 4.9 and 4.10 of
 IANA-POLICY}}.
 
-Capsule types with a value of the form 0x29 * N + 0x17 for integer values of N
+Capsule Types with a value of the form 0x29 * N + 0x17 for integer values of N
 are reserved to exercise the requirement that unknown Capsule Types be ignored.
 These capsules have no semantics and can carry arbitrary values. These values
 MUST NOT be assigned by IANA and MUST NOT appear in the listing of assigned

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -309,7 +309,7 @@ Capsule {
 
 Capsule Type:
 
-: A variable-length integer indicating the Type of the capsule. An IANA registry
+: A variable-length integer indicating the Type of the Capsule. An IANA registry
 is used to manage the assignment of Capsule Types; see {{iana-types}}.
 
 Capsule Length:
@@ -319,7 +319,7 @@ as a variable-length integer. Note that this field can have a value of zero.
 
 Capsule Value:
 
-: The payload of this capsule. Its semantics are determined by the value of the
+: The payload of this Capsule. Its semantics are determined by the value of the
 Capsule Type field.
 
 An intermediary can identify the use of the Capsule Protocol either through the
@@ -328,9 +328,9 @@ chosen HTTP Upgrade token.
 
 Because new protocols or extensions might define new Capsule Types,
 intermediaries that wish to allow for future extensibility SHOULD forward
-capsules without modification unless the definition of the Capsule Type in use
+Capsules without modification unless the definition of the Capsule Type in use
 specifies additional intermediary processing. One such Capsule Type is the
-DATAGRAM capsule; see {{datagram-capsule}}. In particular, intermediaries SHOULD
+DATAGRAM Capsule; see {{datagram-capsule}}. In particular, intermediaries SHOULD
 forward Capsules with an unknown Capsule Type without modification.
 
 Endpoints that receive a Capsule with an unknown Capsule Type MUST silently
@@ -357,10 +357,10 @@ codes 204 (No Content), 205 (Reset Content), and 206 (Partial Content) MUST NOT
 be sent on responses that use the Capsule Protocol. A receiver that observes a
 violation of these requirements MUST treat the HTTP message as malformed.
 
-When processing capsules, a receiver might be tempted to accumulate the full
-length of the capsule value in the data stream before handling it. This approach
+When processing Capsules, a receiver might be tempted to accumulate the full
+length of the Capsule value in the data stream before handling it. This approach
 SHOULD be avoided because it can consume flow control in underlying layers, and
-that might lead to deadlocks if the capsule data exhausts the flow control
+that might lead to deadlocks if the Capsule data exhausts the flow control
 window.
 
 
@@ -373,16 +373,16 @@ message. For HTTP/3, the handling of malformed messages is described in
 described in {{Section 8.1.1 of H2}}. For HTTP/1.x, the handling of incomplete
 messages is described in {{Section 8 of H1}}.
 
-Each capsule's payload MUST contain exactly the fields identified in its
-description. A capsule payload that contains additional bytes after the
-identified fields or a capsule payload that terminates before the end of the
+Each Capsule's payload MUST contain exactly the fields identified in its
+description. A Capsule payload that contains additional bytes after the
+identified fields or a Capsule payload that terminates before the end of the
 identified fields MUST be treated as it if were a malformed or incomplete
 message. In particular, redundant length encodings MUST be verified to be
 self-consistent.
 
-If the receive side of a stream carrying capsules is terminated cleanly (for
+If the receive side of a stream carrying Capsules is terminated cleanly (for
 example, in HTTP/3 this is defined as receiving a QUIC STREAM frame with the FIN
-bit set) and the last capsule on the stream was truncated, this MUST be treated
+bit set) and the last Capsule on the stream was truncated, this MUST be treated
 as if it were a malformed or incomplete message.
 
 
@@ -415,7 +415,7 @@ upgrade tokens that use the Capsule Protocol MAY alter this recommendation.
 
 ## The DATAGRAM Capsule {#datagram-capsule}
 
-This document defines the DATAGRAM (0x00) Capsule Type. This capsule allows HTTP
+This document defines the DATAGRAM (0x00) Capsule Type. This Capsule allows HTTP
 Datagrams to be sent on a stream using the Capsule Protocol. This is
 particularly useful when HTTP is running over a transport that does not support
 the QUIC DATAGRAM frame.
@@ -434,46 +434,46 @@ HTTP Datagram Payload:
 : The payload of the datagram, whose semantics are defined by the extension that
 is using HTTP Datagrams. Note that this field can be empty.
 
-HTTP Datagrams sent using the DATAGRAM capsule have the same semantics as those
+HTTP Datagrams sent using the DATAGRAM Capsule have the same semantics as those
 sent in QUIC DATAGRAM frames. In particular, the restrictions on when it is
 allowed to send an HTTP Datagram and how to process them (from {{format}}) also
-apply to HTTP Datagrams sent and received using the DATAGRAM capsule.
+apply to HTTP Datagrams sent and received using the DATAGRAM Capsule.
 
 An intermediary can re-encode HTTP Datagrams as it forwards them. In other
-words, an intermediary MAY send a DATAGRAM capsule to forward an HTTP Datagram
+words, an intermediary MAY send a DATAGRAM Capsule to forward an HTTP Datagram
 that was received in a QUIC DATAGRAM frame and vice versa. Intermediaries MUST
 NOT perform this re-encoding unless they have identified the use of the Capsule
 Protocol on the corresponding request stream; see {{capsule-protocol}}.
 
-Note that while DATAGRAM capsules that are sent on a stream are reliably
-delivered in order, intermediaries can re-encode DATAGRAM capsules into QUIC
+Note that while DATAGRAM Capsules that are sent on a stream are reliably
+delivered in order, intermediaries can re-encode DATAGRAM Capsules into QUIC
 DATAGRAM frames when forwarding messages, which could result in loss or
 reordering.
 
 If an intermediary receives an HTTP Datagram in a QUIC DATAGRAM frame and is
 forwarding it on a connection that supports QUIC DATAGRAM frames, the
-intermediary SHOULD NOT convert that HTTP Datagram to a DATAGRAM capsule. If the
+intermediary SHOULD NOT convert that HTTP Datagram to a DATAGRAM Capsule. If the
 HTTP Datagram is too large to fit in a DATAGRAM frame (for example, because the
 Path MTU (PMTU) of that QUIC connection is too low or if the maximum UDP payload
 size advertised on that connection is too low), the intermediary SHOULD drop the
-HTTP Datagram instead of converting it to a DATAGRAM capsule. This preserves the
+HTTP Datagram instead of converting it to a DATAGRAM Capsule. This preserves the
 end-to-end unreliability characteristic that methods such as Datagram
 Packetization Layer PMTU Discovery (DPLPMTUD) depend on {{?DPLPMTUD=RFC8899}}.
-An intermediary that converts QUIC DATAGRAM frames to DATAGRAM capsules allows
+An intermediary that converts QUIC DATAGRAM frames to DATAGRAM Capsules allows
 HTTP Datagrams to be arbitrarily large without suffering any loss. This can
 misrepresent the true path properties, defeating methods such as DPLPMTUD.
 
-While DATAGRAM capsules can theoretically carry a payload of length
+While DATAGRAM Capsules can theoretically carry a payload of length
 2<sup>62</sup>-1, most HTTP extensions that use HTTP Datagrams will have their
 own limits on what datagram payload sizes are practical. Implementations SHOULD
-take those limits into account when parsing DATAGRAM capsules. If an incoming
-DATAGRAM capsule has a length that is known to be so large as to not be usable,
-the implementation SHOULD discard the capsule without buffering its contents
+take those limits into account when parsing DATAGRAM Capsules. If an incoming
+DATAGRAM Capsule has a length that is known to be so large as to not be usable,
+the implementation SHOULD discard the Capsule without buffering its contents
 into memory.
 
 Since QUIC DATAGRAM frames are required to fit within a QUIC packet,
-implementations that re-encode DATAGRAM capsules into QUIC DATAGRAM frames might
-be tempted to accumulate the entire capsule in the stream before re-encoding it.
+implementations that re-encode DATAGRAM Capsules into QUIC DATAGRAM frames might
+be tempted to accumulate the entire Capsule in the stream before re-encoding it.
 This SHOULD be avoided, because it can cause flow control problems; see
 {{capsule-protocol}}.
 
@@ -612,7 +612,7 @@ IANA-POLICY}}.
 
 Capsule Types with a value of the form 0x29 * N + 0x17 for integer values of N
 are reserved to exercise the requirement that unknown Capsule Types be ignored.
-These capsules have no semantics and can carry arbitrary values. These values
+These Capsules have no semantics and can carry arbitrary values. These values
 MUST NOT be assigned by IANA and MUST NOT appear in the listing of assigned
 values.
 

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -113,6 +113,9 @@ necessary.
 In this document, the term "intermediary" refers to an HTTP intermediary as
 defined in {{Section 3.7 of HTTP}}.
 
+This document uses the following terminology from {{Section 3 of
+!STRUCTURED-FIELDS=RFC8941}} to specify syntax and parsing: Item.
+
 
 # HTTP Datagrams {#datagrams}
 
@@ -385,12 +388,12 @@ as if it were a malformed or incomplete message.
 
 ## The Capsule-Protocol Header Field {#hdr}
 
-The "Capsule-Protocol" header field is an Item Structured Field; see {{Section
-3.3 of !STRUCTURED-FIELDS=RFC8941}}. Its value MUST be a Boolean; any other
-value type MUST be handled as if the field were not present by recipients (for
-example, if this field is included multiple times, its type will become a List
-and the field will be ignored). This document does not define any parameters for
-the Capsule-Protocol header field value, but future documents might define
+The "Capsule-Protocol" header field is an Item; see {{Section 3.3 of
+!STRUCTURED-FIELDS=RFC8941}}. Its value MUST be a Boolean; any other value type
+MUST be handled as if the field were not present by recipients (for example, if
+this field is included multiple times, its type will become a List and the field
+will be ignored). This document does not define any parameters for the
+Capsule-Protocol header field value, but future documents might define
 parameters. Receivers MUST ignore unknown parameters.
 
 Endpoints indicate that the Capsule Protocol is in use on a data stream by

--- a/draft-ietf-masque-h3-datagram.md
+++ b/draft-ietf-masque-h3-datagram.md
@@ -75,9 +75,10 @@ not applications.
 
 HTTP extensions (as defined in {{Section 16 of !HTTP=RFC9110}}) sometimes need
 to access underlying transport protocol features such as unreliable delivery (as
-offered by {{!DGRAM=RFC9221}}) to enable desirable features. For example, this
-could allow for the introduction of an unreliable version of the CONNECT method
-and the addition of unreliable delivery to WebSockets {{?WEBSOCKET=RFC6455}}.
+offered by {{!QUIC-DGRAM=RFC9221}}) to enable desirable features. For example,
+this could allow for the introduction of an unreliable version of the CONNECT
+method and the addition of unreliable delivery to WebSockets
+{{?WEBSOCKET=RFC6455}}.
 
 In {{datagrams}}, this document describes HTTP Datagrams: a convention that
 supports the bidirectional and optionally multiplexed exchange of data inside an
@@ -87,7 +88,7 @@ extensions (such as the CONNECT method) and are compatible with all versions of
 HTTP.
 
 When HTTP is running over a transport protocol that supports unreliable delivery
-(such as when the QUIC DATAGRAM extension {{DGRAM}} is available to HTTP/3
+(such as when the QUIC DATAGRAM extension {{QUIC-DGRAM}} is available to HTTP/3
 {{H3}}), HTTP Datagrams can use that capability.
 
 In {{capsule}}, this document describes the HTTP Capsule Protocol, which allows


### PR DESCRIPTION
- Add Notes: None to all IANA registrations
- s/DGRAM/QUIC-DGRAM
- s/STRUCT-FIELDS/STRUCTURED-FIELDS
- Use HTTP style for SF field declaration

[Diff with AUTH48 branch](https://www.ietf.org/rfcdiff?url1=https://ietf-wg-masque.github.io/draft-ietf-masque-h3-datagram/auth48/draft-ietf-masque-h3-datagram.txt&url2=https://ietf-wg-masque.github.io/draft-ietf-masque-h3-datagram/fix-219/draft-ietf-masque-h3-datagram.txt)

Fixes #219 